### PR TITLE
refactor: Alter NonTerminal merge functions signature to accept only NonTerminal nodes

### DIFF
--- a/merge/src/merge.rs
+++ b/merge/src/merge.rs
@@ -47,16 +47,15 @@ pub fn merge<'a>(
             }
         }
         (
-            CSTNode::NonTerminal { .. },
-            CSTNode::NonTerminal(non_terminal_left),
-            CSTNode::NonTerminal(non_terminal_right),
+            CSTNode::NonTerminal(a_base),
+            CSTNode::NonTerminal(a_left),
+            CSTNode::NonTerminal(a_right),
         ) => {
-            if non_terminal_left.are_children_unordered && non_terminal_right.are_children_unordered
-            {
+            if a_left.are_children_unordered && a_right.are_children_unordered {
                 Ok(unordered_merge(
-                    base,
-                    left,
-                    right,
+                    a_base,
+                    a_left,
+                    a_right,
                     base_left_matchings,
                     base_right_matchings,
                     left_right_matchings,

--- a/merge/src/merge.rs
+++ b/merge/src/merge.rs
@@ -62,9 +62,9 @@ pub fn merge<'a>(
                 )?)
             } else {
                 Ok(ordered_merge(
-                    base,
-                    left,
-                    right,
+                    a_base,
+                    a_left,
+                    a_right,
                     base_left_matchings,
                     base_right_matchings,
                     left_right_matchings,

--- a/merge/src/merge.rs
+++ b/merge/src/merge.rs
@@ -46,14 +46,9 @@ pub fn merge<'a>(
                 Ok(right.to_owned().into())
             }
         }
-        (
-            CSTNode::NonTerminal(a_base),
-            CSTNode::NonTerminal(a_left),
-            CSTNode::NonTerminal(a_right),
-        ) => {
+        (CSTNode::NonTerminal(_), CSTNode::NonTerminal(a_left), CSTNode::NonTerminal(a_right)) => {
             if a_left.are_children_unordered && a_right.are_children_unordered {
                 Ok(unordered_merge(
-                    a_base,
                     a_left,
                     a_right,
                     base_left_matchings,
@@ -62,7 +57,6 @@ pub fn merge<'a>(
                 )?)
             } else {
                 Ok(ordered_merge(
-                    a_base,
                     a_left,
                     a_right,
                     base_left_matchings,

--- a/merge/src/ordered_merge.rs
+++ b/merge/src/ordered_merge.rs
@@ -4,7 +4,6 @@ use model::cst_node::NonTerminal;
 use crate::{MergeError, MergedCSTNode};
 
 pub fn ordered_merge<'a>(
-    _base: &'a NonTerminal<'a>,
     left: &'a NonTerminal<'a>,
     right: &'a NonTerminal<'a>,
     base_left_matchings: &'a Matchings<'a>,
@@ -222,7 +221,6 @@ mod tests {
         let matchings_parents = ordered_tree_matching(parent_a, parent_b);
 
         let merged_tree = ordered_merge(
-            base.try_into().unwrap(),
             parent_a.try_into().unwrap(),
             parent_b.try_into().unwrap(),
             &matchings_base_parent_a,
@@ -230,7 +228,6 @@ mod tests {
             &matchings_parents,
         )?;
         let merged_tree_swap = ordered_merge(
-            base.try_into().unwrap(),
             parent_b.try_into().unwrap(),
             parent_a.try_into().unwrap(),
             &matchings_base_parent_b,
@@ -255,7 +252,6 @@ mod tests {
         let matchings_parents = ordered_tree_matching(parent_a, parent_b);
 
         let merged_tree = ordered_merge(
-            base.try_into().unwrap(),
             parent_a.try_into().unwrap(),
             parent_b.try_into().unwrap(),
             &matchings_base_parent_a,
@@ -583,7 +579,6 @@ mod tests {
         let matchings_parents = ordered_tree_matching(&parent_a, &parent_b);
 
         let merged_tree = ordered_merge(
-            (&base).try_into().unwrap(),
             (&parent_a).try_into().unwrap(),
             (&parent_b).try_into().unwrap(),
             &matchings_base_parent_a,
@@ -591,7 +586,6 @@ mod tests {
             &matchings_parents,
         )?;
         let merged_tree_swap = ordered_merge(
-            (&base).try_into().unwrap(),
             (&parent_b).try_into().unwrap(),
             (&parent_a).try_into().unwrap(),
             &matchings_base_parent_b,

--- a/merge/src/unordered_merge.rs
+++ b/merge/src/unordered_merge.rs
@@ -9,7 +9,6 @@ use model::{
 use crate::{merge, MergeError, MergedCSTNode};
 
 pub fn unordered_merge<'a>(
-    _base: &'a NonTerminal<'a>,
     left: &'a NonTerminal<'a>,
     right: &'a NonTerminal<'a>,
     base_left_matchings: &'a Matchings<'a>,
@@ -163,7 +162,6 @@ mod tests {
         let matchings_parents = unordered_tree_matching(parent_a, parent_b);
 
         let merged_tree = unordered_merge(
-            base.try_into().unwrap(),
             parent_a.try_into().unwrap(),
             parent_b.try_into().unwrap(),
             &matchings_base_parent_a,
@@ -171,7 +169,6 @@ mod tests {
             &matchings_parents,
         )?;
         let merged_tree_swap = unordered_merge(
-            base.try_into().unwrap(),
             parent_b.try_into().unwrap(),
             parent_a.try_into().unwrap(),
             &matchings_base_parent_b,
@@ -196,7 +193,6 @@ mod tests {
         let matchings_parents = unordered_tree_matching(parent_a, parent_b);
 
         let merged_tree = unordered_merge(
-            base.try_into().unwrap(),
             parent_a.try_into().unwrap(),
             parent_b.try_into().unwrap(),
             &matchings_base_parent_a,

--- a/merge/src/unordered_merge.rs
+++ b/merge/src/unordered_merge.rs
@@ -9,158 +9,143 @@ use model::{
 use crate::{merge, MergeError, MergedCSTNode};
 
 pub fn unordered_merge<'a>(
-    base: &'a CSTNode<'a>,
-    left: &'a CSTNode<'a>,
-    right: &'a CSTNode<'a>,
+    _base: &'a NonTerminal<'a>,
+    left: &'a NonTerminal<'a>,
+    right: &'a NonTerminal<'a>,
     base_left_matchings: &'a Matchings<'a>,
     base_right_matchings: &'a Matchings<'a>,
     left_right_matchings: &'a Matchings<'a>,
 ) -> Result<MergedCSTNode<'a>, MergeError> {
-    match (base, left, right) {
-        (
-            CSTNode::NonTerminal(NonTerminal { kind, .. }),
-            CSTNode::NonTerminal(NonTerminal {
-                children: children_left,
-                ..
-            }),
-            CSTNode::NonTerminal(NonTerminal {
-                children: children_right,
-                ..
-            }),
-        ) => {
-            let mut result_children = vec![];
-            let mut processed_nodes: HashSet<&CSTNode> = HashSet::new();
+    let mut result_children = vec![];
+    let mut processed_nodes: HashSet<&CSTNode> = HashSet::new();
 
-            for left_child in children_left.iter() {
-                match left_child {
-                    CSTNode::Terminal(Terminal { value, .. }) => {
-                        if value == &"}" {
-                            break;
-                        }
-                    }
-                    CSTNode::NonTerminal { .. } => {}
-                }
-
-                let matching_base_left = base_left_matchings.find_matching_for(left_child);
-                let matching_left_right = left_right_matchings.find_matching_for(left_child);
-
-                match (matching_base_left, matching_left_right) {
-                    // Added only by left
-                    (None, None) => {
-                        result_children.push(left_child.to_owned().into());
-                        processed_nodes.insert(left_child);
-                    }
-                    (None, Some(right_matching)) => {
-                        result_children.push(
-                            merge(
-                                left_child,
-                                left_child,
-                                right_matching.matching_node,
-                                base_left_matchings,
-                                base_right_matchings,
-                                left_right_matchings,
-                            )
-                            .unwrap(),
-                        );
-                        processed_nodes.insert(left_child);
-                        processed_nodes.insert(right_matching.matching_node);
-                    }
-                    // Removed in right
-                    (Some(matching_base_left), None) => {
-                        // Changed in left, conflict!
-                        if !matching_base_left.is_perfect_match {
-                            result_children.push(MergedCSTNode::Conflict {
-                                left: Some(Box::new(left_child.to_owned().into())),
-                                right: None,
-                            })
-                        }
-                        processed_nodes.insert(left_child);
-                    }
-                    (Some(_), Some(right_matching)) => {
-                        result_children.push(
-                            merge(
-                                left_child,
-                                left_child,
-                                right_matching.matching_node,
-                                base_left_matchings,
-                                base_right_matchings,
-                                left_right_matchings,
-                            )
-                            .unwrap(),
-                        );
-                        processed_nodes.insert(left_child);
-                        processed_nodes.insert(right_matching.matching_node);
-                    }
+    for left_child in left.children.iter() {
+        match left_child {
+            CSTNode::Terminal(Terminal { value, .. }) => {
+                if value == &"}" {
+                    break;
                 }
             }
-
-            for right_child in children_right.iter() {
-                if processed_nodes.contains(right_child) {
-                    continue;
-                }
-
-                let matching_base_right = base_right_matchings.find_matching_for(right_child);
-                let matching_left_right = left_right_matchings.find_matching_for(right_child);
-
-                match (matching_base_right, matching_left_right) {
-                    // Added only by right
-                    (None, None) => {
-                        result_children.push(right_child.to_owned().into());
-                    }
-                    (None, Some(matching_left_right)) => {
-                        result_children.push(
-                            merge(
-                                right_child,
-                                matching_left_right.matching_node,
-                                right_child,
-                                base_left_matchings,
-                                base_right_matchings,
-                                left_right_matchings,
-                            )
-                            .unwrap(),
-                        );
-                    }
-                    // Removed in left
-                    (Some(matching_base_right), None) => {
-                        // Changed in right, conflict!
-                        if !matching_base_right.is_perfect_match {
-                            result_children.push(MergedCSTNode::Conflict {
-                                left: None,
-                                right: Some(Box::new(right_child.to_owned().into())),
-                            })
-                        }
-                    }
-                    (Some(_), Some(matching_left_right)) => {
-                        result_children.push(
-                            merge(
-                                right_child,
-                                matching_left_right.matching_node,
-                                right_child,
-                                base_left_matchings,
-                                base_right_matchings,
-                                left_right_matchings,
-                            )
-                            .unwrap(),
-                        );
-                    }
-                }
-            }
-
-            Ok(MergedCSTNode::NonTerminal {
-                kind,
-                children: result_children,
-            })
+            CSTNode::NonTerminal { .. } => {}
         }
-        (_, _, _) => Err(MergeError::MergingTerminalWithNonTerminal),
+
+        let matching_base_left = base_left_matchings.find_matching_for(left_child);
+        let matching_left_right = left_right_matchings.find_matching_for(left_child);
+
+        match (matching_base_left, matching_left_right) {
+            // Added only by left
+            (None, None) => {
+                result_children.push(left_child.to_owned().into());
+                processed_nodes.insert(left_child);
+            }
+            (None, Some(right_matching)) => {
+                result_children.push(
+                    merge(
+                        left_child,
+                        left_child,
+                        right_matching.matching_node,
+                        base_left_matchings,
+                        base_right_matchings,
+                        left_right_matchings,
+                    )
+                    .unwrap(),
+                );
+                processed_nodes.insert(left_child);
+                processed_nodes.insert(right_matching.matching_node);
+            }
+            // Removed in right
+            (Some(matching_base_left), None) => {
+                // Changed in left, conflict!
+                if !matching_base_left.is_perfect_match {
+                    result_children.push(MergedCSTNode::Conflict {
+                        left: Some(Box::new(left_child.to_owned().into())),
+                        right: None,
+                    })
+                }
+                processed_nodes.insert(left_child);
+            }
+            (Some(_), Some(right_matching)) => {
+                result_children.push(
+                    merge(
+                        left_child,
+                        left_child,
+                        right_matching.matching_node,
+                        base_left_matchings,
+                        base_right_matchings,
+                        left_right_matchings,
+                    )
+                    .unwrap(),
+                );
+                processed_nodes.insert(left_child);
+                processed_nodes.insert(right_matching.matching_node);
+            }
+        }
     }
+
+    for right_child in right.children.iter() {
+        if processed_nodes.contains(right_child) {
+            continue;
+        }
+
+        let matching_base_right = base_right_matchings.find_matching_for(right_child);
+        let matching_left_right = left_right_matchings.find_matching_for(right_child);
+
+        match (matching_base_right, matching_left_right) {
+            // Added only by right
+            (None, None) => {
+                result_children.push(right_child.to_owned().into());
+            }
+            (None, Some(matching_left_right)) => {
+                result_children.push(
+                    merge(
+                        right_child,
+                        matching_left_right.matching_node,
+                        right_child,
+                        base_left_matchings,
+                        base_right_matchings,
+                        left_right_matchings,
+                    )
+                    .unwrap(),
+                );
+            }
+            // Removed in left
+            (Some(matching_base_right), None) => {
+                // Changed in right, conflict!
+                if !matching_base_right.is_perfect_match {
+                    result_children.push(MergedCSTNode::Conflict {
+                        left: None,
+                        right: Some(Box::new(right_child.to_owned().into())),
+                    })
+                }
+            }
+            (Some(_), Some(matching_left_right)) => {
+                result_children.push(
+                    merge(
+                        right_child,
+                        matching_left_right.matching_node,
+                        right_child,
+                        base_left_matchings,
+                        base_right_matchings,
+                        left_right_matchings,
+                    )
+                    .unwrap(),
+                );
+            }
+        }
+    }
+
+    Ok(MergedCSTNode::NonTerminal {
+        kind: left.kind,
+        children: result_children,
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use matching::{unordered_tree_matching, Matchings};
+    use matching::unordered_tree_matching;
     use model::{
         cst_node::{NonTerminal, Terminal},
-        CSTNode, Point,
+        CSTNode,
     };
 
     use crate::{MergeError, MergedCSTNode};
@@ -178,17 +163,17 @@ mod tests {
         let matchings_parents = unordered_tree_matching(parent_a, parent_b);
 
         let merged_tree = unordered_merge(
-            base,
-            parent_a,
-            parent_b,
+            base.try_into().unwrap(),
+            parent_a.try_into().unwrap(),
+            parent_b.try_into().unwrap(),
             &matchings_base_parent_a,
             &matchings_base_parent_b,
             &matchings_parents,
         )?;
         let merged_tree_swap = unordered_merge(
-            base,
-            parent_b,
-            parent_a,
+            base.try_into().unwrap(),
+            parent_b.try_into().unwrap(),
+            parent_a.try_into().unwrap(),
             &matchings_base_parent_b,
             &matchings_base_parent_a,
             &matchings_parents,
@@ -211,9 +196,9 @@ mod tests {
         let matchings_parents = unordered_tree_matching(parent_a, parent_b);
 
         let merged_tree = unordered_merge(
-            base,
-            parent_a,
-            parent_b,
+            base.try_into().unwrap(),
+            parent_a.try_into().unwrap(),
+            parent_b.try_into().unwrap(),
             &matchings_base_parent_a,
             &matchings_base_parent_b,
             &matchings_parents,
@@ -741,38 +726,5 @@ mod tests {
                 ],
             },
         )
-    }
-
-    #[test]
-    fn test_can_not_merge_terminal_with_non_terminal() -> Result<(), Box<dyn std::error::Error>> {
-        let error = unordered_merge(
-            &CSTNode::Terminal(Terminal {
-                kind: "kind",
-                start_position: Point { row: 0, column: 0 },
-                end_position: Point { row: 0, column: 7 },
-                value: "value",
-            }),
-            &CSTNode::Terminal(Terminal {
-                kind: "kind",
-                start_position: Point { row: 0, column: 0 },
-                end_position: Point { row: 0, column: 7 },
-                value: "value",
-            }),
-            &CSTNode::NonTerminal(NonTerminal {
-                kind: "kind",
-                are_children_unordered: false,
-                start_position: Point { row: 0, column: 0 },
-                end_position: Point { row: 0, column: 7 },
-                children: vec![],
-            }),
-            &Matchings::empty(),
-            &Matchings::empty(),
-            &Matchings::empty(),
-        )
-        .unwrap_err();
-
-        assert_eq!(error, MergeError::MergingTerminalWithNonTerminal);
-
-        Ok(())
     }
 }

--- a/model/src/cst_node.rs
+++ b/model/src/cst_node.rs
@@ -21,6 +21,17 @@ pub struct NonTerminal<'a> {
     pub are_children_unordered: bool,
 }
 
+impl<'a> TryFrom<&'a CSTNode<'a>> for &'a NonTerminal<'a> {
+    type Error = &'static str;
+
+    fn try_from(node: &'a CSTNode<'a>) -> Result<Self, Self::Error> {
+        match node {
+            CSTNode::NonTerminal(non_terminal) => Ok(non_terminal),
+            CSTNode::Terminal(_) => Err("Cannot convert terminal to non-terminal"),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Eq, PartialOrd, Ord, Hash)]
 pub struct Terminal<'a> {
     pub kind: &'a str,


### PR DESCRIPTION
The idea of this refactor is to use the type system to only allow (un)ordered to be called on NonTerminal nodes, since calling them on Terminal ones makes absolutely no sense. We also remove the possibility of (un)ordered merge erroring because of trying to merge Terminal with NonTerminal, letting us get rid of a test.