### PR TITLE
feat(matching): Use handlers for calculating root matching in ordered matching

### DIFF
--- a/matching/src/ordered_tree_matching.rs
+++ b/matching/src/ordered_tree_matching.rs
@@ -36,14 +36,13 @@ pub fn ordered_tree_matching<'a>(
                 ..
             }),
         ) => {
-            let root_matching: usize = (kind_left == kind_right).into();
+            let root_matching: usize = matching_handlers
+                .get_matching_handler_for(left, right)
+                .map_or((kind_left == kind_right).into(), |f| f(left, right));
 
-            // Node kinds do not match, so we return a matching with a score of 0
+            // Node roots do not match, early return
             if root_matching == 0 {
-                return Matchings::from_single(
-                    UnorderedPair(left, right),
-                    MatchingEntry::new(0, false),
-                );
+                return Matchings::empty();
             }
 
             let m = children_left.len();

--- a/matching/src/ordered_tree_matching.rs
+++ b/matching/src/ordered_tree_matching.rs
@@ -37,8 +37,8 @@ pub fn ordered_tree_matching<'a>(
             }),
         ) => {
             let root_matching: usize = matching_handlers
-                .get_matching_handler_for(left, right)
-                .map_or((kind_left == kind_right).into(), |f| f(left, right));
+                .compute_matching_score(left, right)
+                .unwrap_or((kind_left == kind_right).into());
 
             // Node roots do not match, early return
             if root_matching == 0 {

--- a/matching/src/unordered_tree_matching.rs
+++ b/matching/src/unordered_tree_matching.rs
@@ -50,8 +50,9 @@ pub fn unordered_tree_matching<'a>(
 
             for child_left in children_left {
                 for child_right in children_right {
-                    let matching_score =
-                        matching_handlers.compute_matching_score(child_left, child_right);
+                    let matching_score = matching_handlers
+                        .compute_matching_score(child_left, child_right)
+                        .unwrap_or(0);
 
                     if matching_score == 1 {
                         let child_matching =

--- a/matching_handlers/src/lib.rs
+++ b/matching_handlers/src/lib.rs
@@ -28,20 +28,16 @@ impl<'a> MatchingHandlers<'a> {
         self.matching_handlers.insert(key, value);
     }
 
-    pub fn compute_matching_score(&'a self, left: &'a CSTNode, right: &'a CSTNode) -> usize {
-        self.get_matching_handler_for(left, right)
-            .map_or(0, |handler| handler(left, right))
-    }
-
-    pub fn get_matching_handler_for(
+    pub fn compute_matching_score(
         &'a self,
         left: &'a CSTNode,
         right: &'a CSTNode,
-    ) -> Option<&'a MatchingHandler<'a>> {
+    ) -> Option<usize> {
         if left.kind() != right.kind() {
             None
         } else {
-            self.matching_handlers.get(left.kind())
+            let handler = &self.matching_handlers.get(left.kind())?;
+            Some(handler(left, right))
         }
     }
 }

--- a/matching_handlers/src/lib.rs
+++ b/matching_handlers/src/lib.rs
@@ -29,14 +29,20 @@ impl<'a> MatchingHandlers<'a> {
     }
 
     pub fn compute_matching_score(&'a self, left: &'a CSTNode, right: &'a CSTNode) -> usize {
-        if left.kind() != right.kind() {
-            return 0;
-        }
+        self.get_matching_handler_for(left, right)
+            .map_or(0, |handler| handler(left, right))
+    }
 
-        return self
-            .matching_handlers
-            .get(left.kind())
-            .map_or(0, |handler| handler(left, right));
+    pub fn get_matching_handler_for(
+        &'a self,
+        left: &'a CSTNode,
+        right: &'a CSTNode,
+    ) -> Option<&'a MatchingHandler<'a>> {
+        if left.kind() != right.kind() {
+            None
+        } else {
+            self.matching_handlers.get(left.kind())
+        }
     }
 }
 


### PR DESCRIPTION
Currently, the ordered matching algorithm only uses a dummy comparison to calculate the score for the root nodes, checking if they share the same kind. This PR introduces the option to customize this scoring by leveraging the already implemented handlers API.
