### PR TITLE
feat(matching_handlers): Add comparators for class like elements

### DIFF
--- a/matching_handlers/src/java/class_like_declaration.rs
+++ b/matching_handlers/src/java/class_like_declaration.rs
@@ -1,0 +1,61 @@
+use super::utils::find_child_of_kind;
+use model::{cst_node::NonTerminal, CSTNode};
+
+pub fn compute_matching_score_for_class_like_declaration<'a>(
+    left: &'a CSTNode,
+    right: &'a CSTNode,
+) -> usize {
+    match (left, right) {
+        (
+            CSTNode::NonTerminal(NonTerminal {
+                children: children_left,
+                ..
+            }),
+            CSTNode::NonTerminal(NonTerminal {
+                children: children_right,
+                ..
+            }),
+        ) => {
+            let identifier_left =
+                find_child_of_kind(children_left, "identifier").map(|node| node.contents());
+            let identifier_right =
+                find_child_of_kind(children_right, "identifier").map(|node| node.contents());
+
+            (identifier_left.is_some() && identifier_left == identifier_right).into()
+        }
+        (_, _) => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn classes_with_the_same_name_match_with_score_one() {
+        let result = super::compute_matching_score_for_class_like_declaration(
+            &make_class_like_declaration("ABC"),
+            &make_class_like_declaration("ABC"),
+        );
+        assert_eq!(1, result);
+    }
+
+    #[test]
+    fn classes_of_different_names_do_not_match() {
+        let result = super::compute_matching_score_for_class_like_declaration(
+            &make_class_like_declaration("ABC"),
+            &make_class_like_declaration("DEF"),
+        );
+        assert_eq!(0, result);
+    }
+
+    fn make_class_like_declaration(identifier: &str) -> model::CSTNode {
+        model::CSTNode::NonTerminal(model::cst_node::NonTerminal {
+            kind: "class_declaration",
+            children: vec![model::CSTNode::Terminal(model::cst_node::Terminal {
+                kind: "identifier",
+                value: identifier,
+                ..Default::default()
+            })],
+            ..Default::default()
+        })
+    }
+}

--- a/matching_handlers/src/java/mod.rs
+++ b/matching_handlers/src/java/mod.rs
@@ -1,3 +1,4 @@
+mod class_like_declaration;
 mod field_declaration;
 mod import_declaration;
 mod method_declaration;
@@ -6,6 +7,7 @@ mod utils;
 use crate::MatchingHandlers;
 
 use self::{
+    class_like_declaration::compute_matching_score_for_class_like_declaration,
     field_declaration::compute_matching_score_for_field_declaration,
     import_declaration::compute_matching_score_for_import_declaration,
     method_declaration::compute_matching_score_for_method_declaration,
@@ -28,6 +30,14 @@ pub fn get_default_java_matching_handlers<'a>() -> MatchingHandlers<'a> {
     matching_handlers.register(
         "import_declaration",
         compute_matching_score_for_import_declaration,
+    );
+    matching_handlers.register(
+        "class_declaration",
+        compute_matching_score_for_class_like_declaration,
+    );
+    matching_handlers.register(
+        "interface_declaration",
+        compute_matching_score_for_class_like_declaration,
     );
     matching_handlers
 }


### PR DESCRIPTION
In a few cases it may be needed to calculate a matching score between the roots of different classes/interfaces. This will use the identifier to calculate the score for these type of elements and will return 0 if their identifiers do not match.