### PR TITLE
perf: Use Cow for value in MergedCSTNode

### DIFF
--- a/bin/src/control.rs
+++ b/bin/src/control.rs
@@ -1,6 +1,6 @@
 use std::{
     error::Error,
-    fmt::{self, Display},
+    fmt::{self, Display}, time::Instant,
 };
 
 use matching::MatchingEntry;
@@ -58,33 +58,40 @@ pub fn run_tool_on_merge_scenario(
 
     let parser_configuration = ParserConfiguration::from(language);
 
+    let start = Instant::now();
     log::info!("Started parsing base file");
     let base_tree =
         parsing::parse_string(base, &parser_configuration).map_err(ExecutionError::ParsingError)?;
-    log::info!("Finished parsing base file");
+    log::info!("Finished parsing base file in {:?}", start.elapsed());
 
+    let start = Instant::now();
     log::info!("Started parsing left file");
     let left_tree =
         parsing::parse_string(left, &parser_configuration).map_err(ExecutionError::ParsingError)?;
-    log::info!("Finished parsing left file");
+    log::info!("Finished parsing left file in {:?}", start.elapsed());
 
+    let start = Instant::now();
     log::info!("Started parsing right file");
     let right_tree = parsing::parse_string(right, &parser_configuration)
         .map_err(ExecutionError::ParsingError)?;
-    log::info!("Finished parsing right file");
+    log::info!("Finished parsing right file in {:?}", start.elapsed());
 
+    let start = Instant::now();
     log::info!("Started calculation of matchings between left and base");
     let matchings_left_base = matching::calculate_matchings(&left_tree, &base_tree);
-    log::info!("Finished calculation of matchings between left and base");
+    log::info!("Finished calculation of matchings between left and base in {:?}", start.elapsed());
 
+    let start = Instant::now();
     log::info!("Started calculation of matchings between right and base");
     let matchings_right_base = matching::calculate_matchings(&right_tree, &base_tree);
-    log::info!("Finished calculation of matchings between right and base");
+    log::info!("Finished calculation of matchings between right and base in {:?}", start.elapsed());
 
+    let start = Instant::now();
     log::info!("Started calculation of matchings between left and right");
     let matchings_left_right = matching::calculate_matchings(&left_tree, &right_tree);
-    log::info!("Finished calculation of matchings between left and right");
+    log::info!("Finished calculation of matchings between left and right in {:?}", start.elapsed());
 
+    let start = Instant::now();
     log::info!("Starting merge of the trees");
     let result = merge::merge(
         &base_tree,
@@ -95,7 +102,7 @@ pub fn run_tool_on_merge_scenario(
         &matchings_left_right,
     )
     .map_err(ExecutionError::MergeError)?;
-    log::info!("Finished merge of the trees");
+    log::info!("Finished merge of the trees in {:?}", start.elapsed());
 
     match result.has_conflict() {
         true => Ok(ExecutionResult::WithConflicts(result.to_string())),

--- a/merge/src/merge_terminals.rs
+++ b/merge/src/merge_terminals.rs
@@ -17,25 +17,25 @@ pub fn merge_terminals<'a>(
 
     // Unchanged
     if left.value == base.value && right.value == base.value {
-        Ok(base.to_owned().into())
+        Ok(base.into())
     // Changed in both
     } else if left.value != base.value && right.value != base.value {
         match diffy::merge(base.value, left.value, right.value) {
             Ok(value) => Ok(MergedCSTNode::Terminal {
                 kind: base.kind,
-                value,
+                value: std::borrow::Cow::Owned(value),
             }),
             Err(value) => Ok(MergedCSTNode::Terminal {
                 kind: base.kind,
-                value,
+                value: std::borrow::Cow::Owned(value),
             }),
         }
     // Only left changed
     } else if left.value != base.value {
-        Ok(left.to_owned().into())
+        Ok(left.into())
     // Only right changed
     } else {
-        Ok(right.to_owned().into())
+        Ok(right.into())
     }
 }
 
@@ -75,7 +75,7 @@ mod tests {
             &node,
             &node,
             &node,
-            &node.clone().into(),
+            &(&node).into(),
         )
     }
 
@@ -113,7 +113,7 @@ mod tests {
             &right,
             &MergedCSTNode::Terminal {
                 kind: "kind",
-                value: "left\nvalue\nright".to_string(),
+                value: std::borrow::Cow::Borrowed("left\nvalue\nright"),
             },
         )
     }
@@ -150,7 +150,7 @@ mod tests {
             merge_terminals(&base, &left, &right)?,
            MergedCSTNode::Terminal {
                 kind: "kind",
-                value: "<<<<<<< ours\nleft_value||||||| original\nvalue=======\nright_value>>>>>>> theirs\n".to_string()
+                value: std::borrow::Cow::Borrowed("<<<<<<< ours\nleft_value||||||| original\nvalue=======\nright_value>>>>>>> theirs\n")
             }
         );
 
@@ -181,7 +181,7 @@ mod tests {
             &base_and_left,
             &base_and_left,
             &changed_parent,
-            &changed_parent.clone().into(),
+            &(&changed_parent).into(),
         )
     }
 

--- a/merge/src/merge_terminals.rs
+++ b/merge/src/merge_terminals.rs
@@ -7,6 +7,8 @@ pub fn merge_terminals<'a>(
     left: &'a Terminal<'a>,
     right: &'a Terminal<'a>,
 ) -> Result<MergedCSTNode<'a>, MergeError> {
+    log::trace!("Calling merge terminal");
+    
     // Nodes of different kind, early return
     if left.kind != right.kind {
         return Err(MergeError::NodesWithDifferentKinds(
@@ -15,11 +17,16 @@ pub fn merge_terminals<'a>(
         ));
     }
 
+    let left_equals_base = left.value == base.value;
+    let right_equals_base = right.value == base.value;
+
     // Unchanged
-    if left.value == base.value && right.value == base.value {
+    if left_equals_base && right_equals_base {
+        log::trace!("Unchanged");
         Ok(base.into())
     // Changed in both
-    } else if left.value != base.value && right.value != base.value {
+    } else if !left_equals_base && !right_equals_base {
+        log::trace!("Changed in both");
         match diffy::merge(base.value, left.value, right.value) {
             Ok(value) => Ok(MergedCSTNode::Terminal {
                 kind: base.kind,
@@ -31,10 +38,12 @@ pub fn merge_terminals<'a>(
             }),
         }
     // Only left changed
-    } else if left.value != base.value {
+    } else if right_equals_base {
+        log::trace!("Only left changed");
         Ok(left.into())
     // Only right changed
     } else {
+        log::trace!("Only right changed");
         Ok(right.into())
     }
 }

--- a/merge/src/merged_cst_node.rs
+++ b/merge/src/merged_cst_node.rs
@@ -9,7 +9,7 @@ use model::{
 pub enum MergedCSTNode<'a> {
     Terminal {
         kind: &'a str,
-        value: String,
+        value: std::borrow::Cow<'a, str>,
     },
     NonTerminal {
         kind: &'a str,
@@ -21,28 +21,25 @@ pub enum MergedCSTNode<'a> {
     },
 }
 
-impl<'a> From<CSTNode<'a>> for MergedCSTNode<'a> {
-    fn from(val: CSTNode<'a>) -> Self {
+impl<'a> From<&'a CSTNode<'a>> for MergedCSTNode<'a> {
+    fn from(val: &'a CSTNode<'a>) -> Self {
         match val {
-            CSTNode::Terminal(Terminal { kind, value, .. }) => MergedCSTNode::Terminal {
-                kind,
-                value: value.to_string(),
-            },
+            CSTNode::Terminal(terminal) => terminal.into(),
             CSTNode::NonTerminal(NonTerminal { kind, children, .. }) => {
                 MergedCSTNode::NonTerminal {
                     kind,
-                    children: children.into_iter().map(|node| node.into()).collect(),
+                    children: children.iter().map(|node| node.into()).collect(),
                 }
             }
         }
     }
 }
 
-impl<'a> From<Terminal<'a>> for MergedCSTNode<'a> {
-    fn from(val: Terminal<'a>) -> Self {
+impl<'a> From<&'a Terminal<'a>> for MergedCSTNode<'a> {
+    fn from(val: &'a Terminal<'a>) -> Self {
         MergedCSTNode::Terminal {
             kind: val.kind,
-            value: val.value.to_string(),
+            value: std::borrow::Cow::Borrowed(val.value),
         }
     }
 }

--- a/merge/src/ordered_merge.rs
+++ b/merge/src/ordered_merge.rs
@@ -72,14 +72,14 @@ pub fn ordered_merge<'a>(
                 if !matching_base_right.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
                         left: None,
-                        right: Some(Box::new(cur_right.to_owned().into())),
+                        right: Some(Box::new(cur_right.into())),
                     });
                 }
 
                 cur_right_option = children_right_it.next();
             }
             (false, Some(_), Some(_), None, None) => {
-                result_children.push(cur_right.to_owned().into());
+                result_children.push(cur_right.into());
 
                 cur_right_option = children_right_it.next();
             }
@@ -87,19 +87,19 @@ pub fn ordered_merge<'a>(
                 if !matching_base_right.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
                         left: None,
-                        right: Some(Box::new(cur_right.to_owned().into())),
+                        right: Some(Box::new(cur_right.into())),
                     })
                 }
                 cur_right_option = children_right_it.next();
             }
             (false, Some(_), None, None, None) => {
-                result_children.push(cur_right.to_owned().into());
+                result_children.push(cur_right.into());
                 cur_right_option = children_right_it.next();
             }
             (false, None, Some(matching_base_left), Some(_), Some(_)) => {
                 if !matching_base_left.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
-                        left: Some(Box::new(cur_left.to_owned().into())),
+                        left: Some(Box::new(cur_left.into())),
                         right: None,
                     });
                 }
@@ -109,7 +109,7 @@ pub fn ordered_merge<'a>(
             (false, None, Some(matching_base_left), Some(_), None) => {
                 if !matching_base_left.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
-                        left: Some(Box::new(cur_left.to_owned().into())),
+                        left: Some(Box::new(cur_left.into())),
                         right: None,
                     })
                 }
@@ -122,16 +122,16 @@ pub fn ordered_merge<'a>(
                 ) {
                     (true, true) => {}
                     (true, false) => result_children.push(MergedCSTNode::Conflict {
-                        left: Some(Box::new(cur_left.to_owned().into())),
+                        left: Some(Box::new(cur_left.into())),
                         right: None,
                     }),
                     (false, true) => result_children.push(MergedCSTNode::Conflict {
                         left: None,
-                        right: Some(Box::new(cur_right.to_owned().into())),
+                        right: Some(Box::new(cur_right.into())),
                     }),
                     (false, false) => result_children.push(MergedCSTNode::Conflict {
-                        left: Some(Box::new(cur_left.to_owned().into())),
-                        right: Some(Box::new(cur_right.to_owned().into())),
+                        left: Some(Box::new(cur_left.into())),
+                        right: Some(Box::new(cur_right.into())),
                     }),
                 };
 
@@ -139,11 +139,11 @@ pub fn ordered_merge<'a>(
                 cur_right_option = children_right_it.next();
             }
             (false, None, Some(matching_base_left), None, None) => {
-                result_children.push(cur_right.to_owned().into());
+                result_children.push(cur_right.into());
 
                 if !matching_base_left.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
-                        left: Some(Box::new(cur_left.to_owned().into())),
+                        left: Some(Box::new(cur_left.into())),
                         right: None,
                     })
                 }
@@ -152,19 +152,19 @@ pub fn ordered_merge<'a>(
                 cur_right_option = children_right_it.next();
             }
             (false, None, None, Some(_), Some(_)) => {
-                result_children.push(cur_left.to_owned().into());
+                result_children.push(cur_left.into());
                 cur_left_option = children_left_it.next();
             }
             (false, None, None, Some(_), None) => {
-                result_children.push(cur_left.to_owned().into());
+                result_children.push(cur_left.into());
                 cur_left_option = children_left_it.next();
             }
             (false, None, None, None, Some(matching_base_right)) => {
-                result_children.push(cur_left.to_owned().into());
+                result_children.push(cur_left.into());
                 if !matching_base_right.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
                         left: None,
-                        right: Some(Box::new(cur_right.to_owned().into())),
+                        right: Some(Box::new(cur_right.into())),
                     })
                 }
 
@@ -173,8 +173,8 @@ pub fn ordered_merge<'a>(
             }
             (false, None, None, None, None) => {
                 result_children.push(MergedCSTNode::Conflict {
-                    left: Some(Box::new(cur_left.to_owned().into())),
-                    right: Some(Box::new(cur_right.to_owned().into())),
+                    left: Some(Box::new(cur_left.into())),
+                    right: Some(Box::new(cur_right.into())),
                 });
 
                 cur_left_option = children_left_it.next();
@@ -193,12 +193,12 @@ pub fn ordered_merge<'a>(
     }
 
     while let Some(cur_left) = cur_left_option {
-        result_children.push(cur_left.to_owned().into());
+        result_children.push(cur_left.into());
         cur_left_option = children_left_it.next();
     }
 
     while let Some(cur_right) = cur_right_option {
-        result_children.push(cur_right.to_owned().into());
+        result_children.push(cur_right.into());
         cur_right_option = children_right_it.next();
     }
 
@@ -210,7 +210,7 @@ pub fn ordered_merge<'a>(
 
 #[cfg(test)]
 mod tests {
-    use std::vec;
+    use std::{borrow::Cow, vec};
 
     use matching::{ordered, Matchings};
     use model::{cst_node::NonTerminal, cst_node::Terminal, CSTNode, Language, Point};
@@ -302,11 +302,13 @@ mod tests {
             ..Default::default()
         });
 
+        let expected_merge = (&tree).into();
+
         assert_merge_is_correct_and_idempotent_with_respect_to_parent_side(
             &tree,
             &tree,
             &tree,
-            &tree.clone().into(),
+            &expected_merge,
         )
     }
 
@@ -348,12 +350,13 @@ mod tests {
             ],
             ..Default::default()
         });
+        let expected_merge = (&parent).into();
 
         assert_merge_is_correct_and_idempotent_with_respect_to_parent_side(
             &base,
             &parent,
             &parent,
-            &parent.clone().into(),
+            &expected_merge,
         )
     }
 
@@ -401,7 +404,7 @@ mod tests {
             kind: "kind",
             children: vec![MergedCSTNode::Terminal {
                 kind: "kind_a",
-                value: "value_a".to_string(),
+                value: Cow::Borrowed("value_a"),
             }],
         };
 
@@ -483,11 +486,11 @@ mod tests {
             children: vec![
                 MergedCSTNode::Terminal {
                     kind: "kind_a",
-                    value: "value_a".to_string(),
+                    value: Cow::Borrowed("value_a"),
                 },
                 MergedCSTNode::Terminal {
                     kind: "kind_b",
-                    value: "value_b".to_string(),
+                    value: Cow::Borrowed("value_b"),
                 },
             ],
         };
@@ -559,7 +562,7 @@ mod tests {
 
             children: vec![MergedCSTNode::Terminal {
                 kind: "kind_b",
-                value: "value_b".to_string(),
+                value: Cow::Borrowed("value_b"),
             }],
         };
 
@@ -676,7 +679,7 @@ mod tests {
                         kind: "another_subtree",
                         children: vec![MergedCSTNode::Terminal {
                             kind: "kind_b",
-                            value: "value_b".to_string(),
+                            value: Cow::Borrowed("value_b"),
                         }],
                     },
                     MergedCSTNode::Conflict {
@@ -685,7 +688,7 @@ mod tests {
                             kind: "subtree",
                             children: vec![MergedCSTNode::Terminal {
                                 kind: "kind_c",
-                                value: "value_c".to_string(),
+                                value: Cow::Borrowed("value_c"),
                             }],
                         })),
                     },
@@ -702,7 +705,7 @@ mod tests {
                         kind: "another_subtree",
                         children: vec![MergedCSTNode::Terminal {
                             kind: "kind_b",
-                            value: "value_b".to_string(),
+                            value: Cow::Borrowed("value_b"),
                         }],
                     },
                     MergedCSTNode::Conflict {
@@ -710,7 +713,7 @@ mod tests {
                             kind: "subtree",
                             children: vec![MergedCSTNode::Terminal {
                                 kind: "kind_c",
-                                value: "value_c".to_string(),
+                                value: Cow::Borrowed("value_c"),
                             }],
                         })),
                         right: None,
@@ -778,11 +781,11 @@ mod tests {
                 children: vec![MergedCSTNode::Conflict {
                     left: Some(Box::new(MergedCSTNode::Terminal {
                         kind: "kind_a",
-                        value: "value_a".to_string(),
+                        value: Cow::Borrowed("value_a"),
                     })),
                     right: Some(Box::new(MergedCSTNode::Terminal {
                         kind: "kind_b",
-                        value: "value_b".to_string(),
+                        value: Cow::Borrowed("value_b"),
                     })),
                 }],
             },
@@ -868,7 +871,7 @@ mod tests {
 
             children: vec![MergedCSTNode::Terminal {
                 kind: "kind_b",
-                value: "value_b".to_string(),
+                value: Cow::Borrowed("value_b"),
             }],
         };
 
@@ -977,14 +980,14 @@ mod tests {
                             kind: "subtree",
                             children: vec![MergedCSTNode::Terminal {
                                 kind: "kind_c",
-                                value: "value_c".to_string(),
+                                value: Cow::Borrowed("value_c"),
                             }],
                         })),
                         right: None,
                     },
                     MergedCSTNode::Terminal {
                         kind: "kind_a",
-                        value: "value_a".to_string(),
+                        value: Cow::Borrowed("value_a"),
                     },
                 ],
             },
@@ -1003,13 +1006,13 @@ mod tests {
                             kind: "subtree",
                             children: vec![MergedCSTNode::Terminal {
                                 kind: "kind_c",
-                                value: "value_c".to_string(),
+                                value: Cow::Borrowed("value_c"),
                             }],
                         })),
                     },
                     MergedCSTNode::Terminal {
                         kind: "kind_a",
-                        value: "value_a".to_string(),
+                        value: Cow::Borrowed("value_a"),
                     },
                 ],
             },
@@ -1113,15 +1116,15 @@ mod tests {
             children: vec![
                 MergedCSTNode::Terminal {
                     kind: "kind_a",
-                    value: "value_a".to_string(),
+                    value: Cow::Borrowed("value_a"),
                 },
                 MergedCSTNode::Terminal {
                     kind: "kind_b",
-                    value: "value_b".to_string(),
+                    value: Cow::Borrowed("value_b"),
                 },
                 MergedCSTNode::Terminal {
                     kind: "kind_c",
-                    value: "value_c".to_string(),
+                    value: Cow::Borrowed("value_c"),
                 },
             ],
         };
@@ -1202,7 +1205,7 @@ mod tests {
 
             children: vec![MergedCSTNode::Terminal {
                 kind: "kind_a",
-                value: "value_a".to_string(),
+                value: Cow::Borrowed("value_a"),
             }],
         };
 
@@ -1306,13 +1309,13 @@ mod tests {
                             kind: "subtree",
                             children: vec![MergedCSTNode::Terminal {
                                 kind: "kind_b",
-                                value: "value_c".to_string(),
+                                value: Cow::Borrowed("value_c"),
                             }],
                         })),
                     },
                     MergedCSTNode::Terminal {
                         kind: "kind_a",
-                        value: "value_a".to_string(),
+                        value: Cow::Borrowed("value_a"),
                     },
                 ],
             },
@@ -1329,14 +1332,14 @@ mod tests {
                             kind: "subtree",
                             children: vec![MergedCSTNode::Terminal {
                                 kind: "kind_b",
-                                value: "value_c".to_string(),
+                                value: Cow::Borrowed("value_c"),
                             }],
                         })),
                         right: None,
                     },
                     MergedCSTNode::Terminal {
                         kind: "kind_a",
-                        value: "value_a".to_string(),
+                        value: Cow::Borrowed("value_a"),
                     },
                 ],
             },
@@ -1405,11 +1408,11 @@ mod tests {
             children: vec![
                 MergedCSTNode::Terminal {
                     kind: "kind_c",
-                    value: "value_c".to_string(),
+                    value: Cow::Borrowed("value_c"),
                 },
                 MergedCSTNode::Terminal {
                     kind: "kind_a",
-                    value: "value_a".to_string(),
+                    value: Cow::Borrowed("value_a"),
                 },
             ],
         };
@@ -1607,7 +1610,7 @@ mod tests {
                         kind: "subtree_b",
                         children: vec![MergedCSTNode::Terminal {
                             kind: "kind_c",
-                            value: "value_c".to_string(),
+                            value: Cow::Borrowed("value_c"),
                         }],
                     })),
                     right: None,
@@ -1626,7 +1629,7 @@ mod tests {
                         kind: "subtree_b",
                         children: vec![MergedCSTNode::Terminal {
                             kind: "kind_c",
-                            value: "value_c".to_string(),
+                            value: Cow::Borrowed("value_c"),
                         }],
                     })),
                 }],

--- a/merge/src/unordered_merge.rs
+++ b/merge/src/unordered_merge.rs
@@ -44,7 +44,7 @@ pub fn unordered_merge<'a>(
         match (matching_base_left, matching_left_right) {
             // Added only by left
             (None, None) => {
-                result_children.push(left_child.to_owned().into());
+                result_children.push(left_child.into());
                 processed_nodes.insert(left_child.id());
             }
             (None, Some(right_matching)) => {
@@ -64,7 +64,7 @@ pub fn unordered_merge<'a>(
                 // Changed in left, conflict!
                 if !matching_base_left.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
-                        left: Some(Box::new(left_child.to_owned().into())),
+                        left: Some(Box::new(left_child.into())),
                         right: None,
                     })
                 }
@@ -96,7 +96,7 @@ pub fn unordered_merge<'a>(
         match (matching_base_right, matching_left_right) {
             // Added only by right
             (None, None) => {
-                result_children.push(right_child.to_owned().into());
+                result_children.push(right_child.into());
             }
             (None, Some(matching_left_right)) => {
                 result_children.push(merge(
@@ -114,7 +114,7 @@ pub fn unordered_merge<'a>(
                 if !matching_base_right.is_perfect_match {
                     result_children.push(MergedCSTNode::Conflict {
                         left: None,
-                        right: Some(Box::new(right_child.to_owned().into())),
+                        right: Some(Box::new(right_child.into())),
                     })
                 }
             }
@@ -299,15 +299,15 @@ mod tests {
             children: vec![
                 MergedCSTNode::Terminal {
                     kind: "{",
-                    value: String::from("{"),
+                    value: std::borrow::Cow::Borrowed("{"),
                 },
                 MergedCSTNode::Terminal {
                     kind: "method_declaration",
-                    value: String::from("main"),
+                    value: std::borrow::Cow::Borrowed("main"),
                 },
                 MergedCSTNode::Terminal {
                     kind: "}",
-                    value: String::from("}"),
+                    value: std::borrow::Cow::Borrowed("}"),
                 },
             ],
         };
@@ -437,18 +437,18 @@ mod tests {
             children: vec![
                 MergedCSTNode::Terminal {
                     kind: "{",
-                    value: String::from("{"),
+                    value: std::borrow::Cow::Borrowed("{"),
                 },
                 MergedCSTNode::NonTerminal {
                     kind: "a_method_declaration",
                     children: vec![MergedCSTNode::Terminal {
                         kind: "identifier",
-                        value: String::from("main"),
+                        value: std::borrow::Cow::Borrowed("main"),
                     }],
                 },
                 MergedCSTNode::Terminal {
                     kind: "}",
-                    value: String::from("}"),
+                    value: std::borrow::Cow::Borrowed("}"),
                 },
             ],
         };
@@ -604,11 +604,11 @@ mod tests {
             children: vec![
                 MergedCSTNode::Terminal {
                     kind: "{",
-                    value: String::from("{"),
+                    value: std::borrow::Cow::Borrowed("{"),
                 },
                 MergedCSTNode::Terminal {
                     kind: "}",
-                    value: String::from("}"),
+                    value: std::borrow::Cow::Borrowed("}"),
                 },
             ],
         };
@@ -799,7 +799,7 @@ mod tests {
                 children: vec![
                     MergedCSTNode::Terminal {
                         kind: "{",
-                        value: String::from("{"),
+                        value: std::borrow::Cow::Borrowed("{"),
                     },
                     MergedCSTNode::Conflict {
                         left: Some(Box::new(MergedCSTNode::NonTerminal {
@@ -807,19 +807,19 @@ mod tests {
                             children: vec![
                                 MergedCSTNode::Terminal {
                                     kind: "formal_parameters",
-                                    value: String::from("formal_parameters"),
+                                    value: std::borrow::Cow::Borrowed("formal_parameters"),
                                 },
                                 MergedCSTNode::Terminal {
                                     kind: "identifier",
-                                    value: String::from("method"),
+                                    value: std::borrow::Cow::Borrowed("method"),
                                 },
                                 MergedCSTNode::Terminal {
                                     kind: "kind_a",
-                                    value: String::from("value_a"),
+                                    value: std::borrow::Cow::Borrowed("value_a"),
                                 },
                                 MergedCSTNode::Terminal {
                                     kind: "kind_b",
-                                    value: String::from("new_value_b"),
+                                    value: std::borrow::Cow::Borrowed("new_value_b"),
                                 },
                             ],
                         })),
@@ -827,7 +827,7 @@ mod tests {
                     },
                     MergedCSTNode::Terminal {
                         kind: "}",
-                        value: String::from("}"),
+                        value: std::borrow::Cow::Borrowed("}"),
                     },
                 ],
             },
@@ -841,7 +841,7 @@ mod tests {
                 children: vec![
                     MergedCSTNode::Terminal {
                         kind: "{",
-                        value: String::from("{"),
+                        value: std::borrow::Cow::Borrowed("{"),
                     },
                     MergedCSTNode::Conflict {
                         left: None,
@@ -850,26 +850,26 @@ mod tests {
                             children: vec![
                                 MergedCSTNode::Terminal {
                                     kind: "formal_parameters",
-                                    value: String::from("formal_parameters"),
+                                    value: std::borrow::Cow::Borrowed("formal_parameters"),
                                 },
                                 MergedCSTNode::Terminal {
                                     kind: "identifier",
-                                    value: String::from("method"),
+                                    value: std::borrow::Cow::Borrowed("method"),
                                 },
                                 MergedCSTNode::Terminal {
                                     kind: "kind_a",
-                                    value: String::from("value_a"),
+                                    value: std::borrow::Cow::Borrowed("value_a"),
                                 },
                                 MergedCSTNode::Terminal {
                                     kind: "kind_b",
-                                    value: String::from("new_value_b"),
+                                    value: std::borrow::Cow::Borrowed("new_value_b"),
                                 },
                             ],
                         })),
                     },
                     MergedCSTNode::Terminal {
                         kind: "}",
-                        value: String::from("}"),
+                        value: std::borrow::Cow::Borrowed("}"),
                     },
                 ],
             },


### PR DESCRIPTION
In most scenarios, we don't need to create a new `String` when merging the values of two CSTNodes. More often than not, we simply pick the value from either the left or right node, or, ideally, the values of both nodes are equal to the base. Consequently, creating owned Strings is uncommon, and it would be more efficient to return a reference to the value of one of the `CSTNodes`.

To accommodate this use case, this PR updates the `MergedCSTNode` to use `Cow<str>` instead of `String`. This change eliminates unnecessary `to_string` calls, potentially leading to performance improvements in some scenarios.