### PR TITLE
perf: Introduce an auxiliary table for efficient matching existence check

### DIFF
--- a/matching/src/matchings.rs
+++ b/matching/src/matchings.rs
@@ -32,7 +32,6 @@ impl<'a> Matchings<'a> {
             individual_matchings: {
                 matching_entries
                     .keys()
-                    .into_iter()
                     .flat_map(|key| [(key.0, key.1), (key.1, key.0)])
                     .collect::<HashMap<&'a CSTNode<'a>, &'a CSTNode<'a>>>()
             },
@@ -65,7 +64,6 @@ impl<'a> Matchings<'a> {
             matchings
                 .matching_entries
                 .keys()
-                .into_iter()
                 .flat_map(|key| [(key.0, key.1), (key.1, key.0)])
                 .collect::<HashMap<&'a CSTNode<'a>, &'a CSTNode<'a>>>(),
         );

--- a/merge/src/ordered_merge.rs
+++ b/merge/src/ordered_merge.rs
@@ -30,10 +30,8 @@ pub fn ordered_merge<'a>(
     while let (Some(cur_left), Some(cur_right)) = (cur_left_option, cur_right_option) {
         let matching_base_left = base_left_matchings.find_matching_for(cur_left);
         let matching_base_right = base_right_matchings.find_matching_for(cur_right);
-        let left_matching_in_right =
-            left_right_matchings.find_matching_node_in_children(cur_left, right.get_children());
-        let right_matching_in_left =
-            left_right_matchings.find_matching_node_in_children(cur_right, left.get_children());
+        let left_matching_in_right = left_right_matchings.find_matching_for(cur_left);
+        let right_matching_in_left = left_right_matchings.find_matching_for(cur_right);
         let has_bidirectional_matching_left_right =
             left_matching_in_right.is_some() && right_matching_in_left.is_some();
 

--- a/merge/src/unordered_merge.rs
+++ b/merge/src/unordered_merge.rs
@@ -39,8 +39,7 @@ pub fn unordered_merge<'a>(
         }
 
         let matching_base_left = base_left_matchings.find_matching_for(left_child);
-        let matching_left_right =
-            left_right_matchings.find_matching_node_in_children(left_child, right.get_children());
+        let matching_left_right = left_right_matchings.find_matching_for(left_child);
 
         match (matching_base_left, matching_left_right) {
             // Added only by left
@@ -92,8 +91,7 @@ pub fn unordered_merge<'a>(
         .filter(|node| !processed_nodes.contains(&node.id()))
     {
         let matching_base_right = base_right_matchings.find_matching_for(right_child);
-        let matching_left_right =
-            left_right_matchings.find_matching_node_in_children(right_child, left.get_children());
+        let matching_left_right = left_right_matchings.find_matching_for(right_child);
 
         match (matching_base_right, matching_left_right) {
             // Added only by right


### PR DESCRIPTION

Sure, here's the revised version with the term "auxiliary HashMap":

This work follows up on #66. Currently, the Matchings API provides a quick way to retrieve a matching entry for two arbitrary nodes. However, a common use case during the merge process involves finding a matching entry for a node without prior knowledge of which other node it matches with. While we have an API for this scenario, it is inefficient as it may iterate over all matchings in the worst case.

This PR introduces an enhancement to address this inefficiency. The approach involves storing an auxiliary HashMap where both the key and value are nodes, say A and B. This way, there is an entry in the HashMap only if there is a matching between node A and B. This allows us to quickly check if a matching for node A exists by simply checking if an entry is present in the HashMap. This change reduces the lookup time to O(1), at the cost of additional memory usage and some performance overhead in building and updating this auxiliary HashMap, which were found to be negligible compared to the performance gains achieved.