### PR TITLE
perf: Improve tree matching performance with identical subtree fast-path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ LANGUAGE=java
 LOG_LEVEL=debug
 
 run_merge_on_dir:
-	cargo run -- merge --left-path=$(DIR)/left$(SUFFIX) --base-path=$(DIR)/base$(SUFFIX) --right-path=$(DIR)/right$(SUFFIX) --merge-path=$(DIR)/merge$(SUFFIX) --log-level=$(LOG_LEVEL)
+	cargo run --release -- merge --left-path=$(DIR)/left$(SUFFIX) --base-path=$(DIR)/base$(SUFFIX) --right-path=$(DIR)/right$(SUFFIX) --merge-path=$(DIR)/merge$(SUFFIX) --log-level=$(LOG_LEVEL)
 
 run_diff:
-	cargo run -- diff --left-path=$(LEFT_PATH) --right-path=$(RIGHT_PATH) --language=$(LANGUAGE) --log-level=$(LOG_LEVEL)
+	cargo run --release -- diff --left-path=$(LEFT) --right-path=$(RIGHT) --log-level=$(LOG_LEVEL)
 
 rebuild_snapshots:
 	for SCENARIO in $(SCENARIOS); do \

--- a/bin/tests/scenarios/java/change_object_in_classe_instantiation/merge.java
+++ b/bin/tests/scenarios/java/change_object_in_classe_instantiation/merge.java
@@ -2,10 +2,20 @@ public class GitHubBuilder {
     private String a;
 
     public GitHubBuilder withProxy(final Proxy p) {
-        return withConnector(new ImpatientHttpConnector(new HttpConnector() {
+        return withConnector(
+<<<<<<<
+new HttpConnector() {
             public HttpURLConnection connect(URL url) throws IOException {
                 return (HttpURLConnection) url.openConnection(p);
             }
-        }));
+        }
+=======
+new ImpatientHttpConnector(new HttpConnector() {
+            public HttpURLConnection connect(URL url) throws IOException {
+                return (HttpURLConnection) url.openConnection(p);
+            }
+        })
+>>>>>>>
+);
     }
 }

--- a/matching/src/matchings.rs
+++ b/matching/src/matchings.rs
@@ -69,6 +69,13 @@ impl<'a> Matchings<'a> {
         );
         self.matching_entries.extend(matchings);
     }
+
+    pub fn push(&mut self, left: &'a CSTNode<'a>, right: &'a CSTNode<'a>, score: usize) {
+        self.extend(Matchings::from_single(
+            UnorderedPair(left, right),
+            MatchingEntry::new(left, right, score),
+        ));
+    }
 }
 
 impl Default for Matchings<'_> {

--- a/matching/src/ordered/identical.rs
+++ b/matching/src/ordered/identical.rs
@@ -1,0 +1,67 @@
+use model::CSTNode;
+
+use crate::{matches::Matches, Matchings};
+
+pub fn identical_matches<'a>(
+    left_children: &'a [CSTNode<'a>],
+    right_children: &'a [CSTNode<'a>],
+    matchings: &mut Matchings<'a>,
+) -> (usize, usize) {
+    let len = left_children.len().min(right_children.len());
+
+    let mut score = 0;
+
+    for i in 0..len {
+        if let Some(child_score) = identical_match(&left_children[i], &right_children[i], matchings)
+        {
+            log::debug!(
+                "Marking {:?} and {:?} as identical",
+                &left_children[i].contents(),
+                &right_children[i].contents()
+            );
+            score += child_score;
+        } else {
+            return (i, score);
+        }
+    }
+
+    (len, score)
+}
+
+fn identical_match<'a>(
+    left: &'a CSTNode<'a>,
+    right: &'a CSTNode<'a>,
+    matchings: &mut Matchings<'a>,
+) -> Option<usize> {
+    if !left.matches(right) {
+        return None;
+    }
+
+    match (left, right) {
+        (CSTNode::Terminal(_), CSTNode::Terminal(_)) => {
+            let score = 1;
+            matchings.push(left, right, score);
+            Some(score)
+        }
+
+        (CSTNode::NonTerminal(nt_left), CSTNode::NonTerminal(nt_right)) => {
+            let left_children = nt_left.get_children();
+            let right_children = nt_right.get_children();
+
+            if left_children.len() != right_children.len() {
+                return None;
+            }
+
+            let mut score = 1;
+
+            for (l, r) in left_children.iter().zip(right_children.iter()) {
+                score += identical_match(l, r, matchings)?;
+            }
+
+            matchings.push(left, right, score);
+            Some(score)
+        }
+
+        _ => None,
+    }
+}

--- a/matching/src/ordered/identical.rs
+++ b/matching/src/ordered/identical.rs
@@ -1,31 +1,47 @@
 use model::CSTNode;
 
 use crate::{matches::Matches, Matchings};
-
 pub fn identical_matches<'a>(
     left_children: &'a [CSTNode<'a>],
     right_children: &'a [CSTNode<'a>],
     matchings: &mut Matchings<'a>,
-) -> (usize, usize) {
+) -> (usize, usize, usize) {
     let len = left_children.len().min(right_children.len());
 
     let mut score = 0;
+    let mut prefix = 0;
 
+    // Find common prefix
     for i in 0..len {
         if let Some(child_score) = identical_match(&left_children[i], &right_children[i], matchings)
         {
-            log::debug!(
-                "Marking {:?} and {:?} as identical",
-                &left_children[i].contents(),
-                &right_children[i].contents()
-            );
             score += child_score;
+            prefix += 1;
         } else {
-            return (i, score);
+            break;
         }
     }
 
-    (len, score)
+    let mut suffix = 0;
+
+    // Find common suffix
+    while suffix < len - prefix {
+        let left_index = left_children.len() - suffix - 1;
+        let right_index = right_children.len() - suffix - 1;
+
+        if let Some(child_score) = identical_match(
+            &left_children[left_index],
+            &right_children[right_index],
+            matchings,
+        ) {
+            score += child_score;
+            suffix += 1;
+        } else {
+            break;
+        }
+    }
+
+    (prefix, suffix, score)
 }
 
 fn identical_match<'a>(

--- a/matching/src/ordered/mod.rs
+++ b/matching/src/ordered/mod.rs
@@ -1,6 +1,7 @@
+mod identical;
 mod yang;
 
-use crate::{matches::Matches, Matchings};
+use crate::{matches::Matches, ordered::identical::identical_matches, Matchings};
 
 pub fn calculate_matchings<'a>(
     left: &'a model::CSTNode,
@@ -10,14 +11,26 @@ pub fn calculate_matchings<'a>(
         (left, right)
     {
         let root_matching: usize = (left.matches(right)).into();
-        let mut matchings = Matchings::empty();
+        let mut matchings: Matchings<'_> = Matchings::empty();
 
-        let maximum_children_score = yang::yang(
+        let (first_identical_roots, identical_children_score) = identical_matches(
             nt_left.get_children(),
             nt_right.get_children(),
             &mut matchings,
         );
-        matchings.push(left, right, maximum_children_score + root_matching);
+
+        log::debug!("Starting calculation at {:?}", first_identical_roots);
+
+        let maximum_children_score = yang::yang(
+            nt_left.get_children()[first_identical_roots..].as_ref(),
+            nt_right.get_children()[first_identical_roots..].as_ref(),
+            &mut matchings,
+        );
+        matchings.push(
+            left,
+            right,
+            identical_children_score + maximum_children_score + root_matching,
+        );
         matchings
     } else {
         Matchings::empty()

--- a/matching/src/ordered/mod.rs
+++ b/matching/src/ordered/mod.rs
@@ -1,89 +1,16 @@
-use crate::{matches::Matches, matching_entry::MatchingEntry, Matchings};
-use unordered_pair::UnorderedPair;
+mod yang;
 
-#[derive(PartialEq, Eq, Debug, Clone)]
-enum Direction {
-    Top,
-    Left,
-    Diag,
-}
-
-#[derive(Clone)]
-struct Entry<'a>(pub Direction, pub Matchings<'a>);
-
-impl Default for Entry<'_> {
-    fn default() -> Self {
-        Self(Direction::Top, Default::default())
-    }
-}
+use crate::{matches::Matches, Matchings};
 
 pub fn calculate_matchings<'a>(
     left: &'a model::CSTNode,
     right: &'a model::CSTNode,
 ) -> Matchings<'a> {
-    match (left, right) {
-        (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) => {
-            let root_matching: usize = (left.matches(right)).into();
-
-            let m = nt_left.get_children().len();
-            let n = nt_right.get_children().len();
-
-            let mut matrix_m = vec![vec![0; n + 1]; m + 1];
-            let mut matrix_t = vec![vec![Entry::default(); n + 1]; m + 1];
-
-            for i in 1..m + 1 {
-                for j in 1..n + 1 {
-                    let left_child = nt_left.get_children().get(i - 1).unwrap();
-                    let right_child = nt_right.get_children().get(j - 1).unwrap();
-
-                    let w = crate::calculate_matchings(left_child, right_child);
-                    let matching = w
-                        .get_matching_entry(left_child, right_child)
-                        .unwrap_or_default();
-
-                    if matrix_m[i][j - 1] > matrix_m[i - 1][j] {
-                        if matrix_m[i][j - 1] > matrix_m[i - 1][j - 1] + matching.score {
-                            matrix_m[i][j] = matrix_m[i][j - 1];
-                            matrix_t[i][j] = Entry(Direction::Left, w);
-                        } else {
-                            matrix_m[i][j] = matrix_m[i - 1][j - 1] + matching.score;
-                            matrix_t[i][j] = Entry(Direction::Diag, w);
-                        }
-                    } else if matrix_m[i - 1][j] > matrix_m[i - 1][j - 1] + matching.score {
-                        matrix_m[i][j] = matrix_m[i - 1][j];
-                        matrix_t[i][j] = Entry(Direction::Top, w);
-                    } else {
-                        matrix_m[i][j] = matrix_m[i - 1][j - 1] + matching.score;
-                        matrix_t[i][j] = Entry(Direction::Diag, w);
-                    }
-                }
-            }
-
-            let mut i = m;
-            let mut j = n;
-
-            let mut matchings = Matchings::from_single(
-                UnorderedPair(left, right),
-                MatchingEntry::new(left, right, matrix_m[m][n] + root_matching),
-            );
-
-            while i >= 1 && j >= 1 {
-                match matrix_t.get(i).unwrap().get(j).unwrap().0 {
-                    Direction::Top => i -= 1,
-                    Direction::Left => j -= 1,
-                    Direction::Diag => {
-                        if matrix_m[i][j] > matrix_m[i - 1][j - 1] {
-                            matchings.extend(matrix_t[i][j].1.clone());
-                        }
-                        i -= 1;
-                        j -= 1;
-                    }
-                }
-            }
-
-            matchings
-        }
-        (_, _) => Matchings::empty(),
+    if let (model::CSTNode::NonTerminal(_), model::CSTNode::NonTerminal(_)) = (left, right) {
+        let root_matching: usize = (left.matches(right)).into();
+        yang::yang(left, right, root_matching)
+    } else {
+        Matchings::empty()
     }
 }
 

--- a/matching/src/ordered/mod.rs
+++ b/matching/src/ordered/mod.rs
@@ -21,24 +21,33 @@ pub fn calculate_matchings<'a>(
 
         let left_children = nt_left.get_children();
         let right_children = nt_right.get_children();
-        log::debug!(
-            "Identical suffix/prefix reduced search space from {:?}x{:?} to {:?}x{:?}",
-            left_children.len(),
-            right_children.len(),
-            left_children.len() - prefix - suffix,
-            right_children.len() - prefix - suffix,
-        );
 
-        let maximum_children_score = yang::yang(
-            left_children[prefix..left_children.len() - suffix].as_ref(),
-            right_children[prefix..right_children.len() - suffix].as_ref(),
-            &mut matchings,
-        );
-        matchings.push(
-            left,
-            right,
-            identical_children_score + maximum_children_score + root_matching,
-        );
+        let remaining_children_left = left_children.len() - prefix - suffix;
+        let remaining_children_right = right_children.len() - prefix - suffix;
+
+        if remaining_children_left == 0 && remaining_children_right == 0 {
+            log::debug!("Identical suffix/prefix fully reduced search space");
+            matchings.push(left, right, identical_children_score + root_matching);
+        } else {
+            log::debug!(
+                "Identical suffix/prefix reduced search space from {:?}x{:?} to {:?}x{:?}",
+                left_children.len(),
+                right_children.len(),
+                remaining_children_left,
+                remaining_children_right,
+            );
+
+            let maximum_children_score = yang::yang(
+                left_children[prefix..left_children.len() - suffix].as_ref(),
+                right_children[prefix..right_children.len() - suffix].as_ref(),
+                &mut matchings,
+            );
+            matchings.push(
+                left,
+                right,
+                identical_children_score + maximum_children_score + root_matching,
+            );
+        }
         matchings
     } else {
         Matchings::empty()

--- a/matching/src/ordered/mod.rs
+++ b/matching/src/ordered/mod.rs
@@ -6,9 +6,19 @@ pub fn calculate_matchings<'a>(
     left: &'a model::CSTNode,
     right: &'a model::CSTNode,
 ) -> Matchings<'a> {
-    if let (model::CSTNode::NonTerminal(_), model::CSTNode::NonTerminal(_)) = (left, right) {
+    if let (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) =
+        (left, right)
+    {
         let root_matching: usize = (left.matches(right)).into();
-        yang::yang(left, right, root_matching)
+        let mut matchings = Matchings::empty();
+
+        let maximum_children_score = yang::yang(
+            nt_left.get_children(),
+            nt_right.get_children(),
+            &mut matchings,
+        );
+        matchings.push(left, right, maximum_children_score + root_matching);
+        matchings
     } else {
         Matchings::empty()
     }

--- a/matching/src/ordered/mod.rs
+++ b/matching/src/ordered/mod.rs
@@ -13,17 +13,25 @@ pub fn calculate_matchings<'a>(
         let root_matching: usize = (left.matches(right)).into();
         let mut matchings: Matchings<'_> = Matchings::empty();
 
-        let (first_identical_roots, identical_children_score) = identical_matches(
+        let (prefix, suffix, identical_children_score) = identical_matches(
             nt_left.get_children(),
             nt_right.get_children(),
             &mut matchings,
         );
 
-        log::debug!("Starting calculation at {:?}", first_identical_roots);
+        let left_children = nt_left.get_children();
+        let right_children = nt_right.get_children();
+        log::debug!(
+            "Identical suffix/prefix reduced search space from {:?}x{:?} to {:?}x{:?}",
+            left_children.len(),
+            right_children.len(),
+            left_children.len() - prefix - suffix,
+            right_children.len() - prefix - suffix,
+        );
 
         let maximum_children_score = yang::yang(
-            nt_left.get_children()[first_identical_roots..].as_ref(),
-            nt_right.get_children()[first_identical_roots..].as_ref(),
+            left_children[prefix..left_children.len() - suffix].as_ref(),
+            right_children[prefix..right_children.len() - suffix].as_ref(),
             &mut matchings,
         );
         matchings.push(

--- a/matching/src/ordered/yang.rs
+++ b/matching/src/ordered/yang.rs
@@ -1,0 +1,88 @@
+use crate::{matches::Matches, matching_entry::MatchingEntry, Matchings};
+use unordered_pair::UnorderedPair;
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+enum Direction {
+    Top,
+    Left,
+    Diag,
+}
+
+#[derive(Clone)]
+struct Entry<'a>(pub Direction, pub Matchings<'a>);
+
+impl Default for Entry<'_> {
+    fn default() -> Self {
+        Self(Direction::Top, Default::default())
+    }
+}
+
+pub fn yang<'a>(
+    left: &'a model::CSTNode,
+    right: &'a model::CSTNode,
+    root_matching: usize,
+) -> Matchings<'a> {
+    if let (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) =
+        (left, right)
+    {
+        let m = nt_left.get_children().len();
+        let n = nt_right.get_children().len();
+
+        let mut matrix_m = vec![vec![0; n + 1]; m + 1];
+        let mut matrix_t = vec![vec![Entry::default(); n + 1]; m + 1];
+
+        for i in 1..m + 1 {
+            for j in 1..n + 1 {
+                let left_child = nt_left.get_children().get(i - 1).unwrap();
+                let right_child = nt_right.get_children().get(j - 1).unwrap();
+
+                let w = crate::calculate_matchings(left_child, right_child);
+                let matching = w
+                    .get_matching_entry(left_child, right_child)
+                    .unwrap_or_default();
+
+                if matrix_m[i][j - 1] > matrix_m[i - 1][j] {
+                    if matrix_m[i][j - 1] > matrix_m[i - 1][j - 1] + matching.score {
+                        matrix_m[i][j] = matrix_m[i][j - 1];
+                        matrix_t[i][j] = Entry(Direction::Left, w);
+                    } else {
+                        matrix_m[i][j] = matrix_m[i - 1][j - 1] + matching.score;
+                        matrix_t[i][j] = Entry(Direction::Diag, w);
+                    }
+                } else if matrix_m[i - 1][j] > matrix_m[i - 1][j - 1] + matching.score {
+                    matrix_m[i][j] = matrix_m[i - 1][j];
+                    matrix_t[i][j] = Entry(Direction::Top, w);
+                } else {
+                    matrix_m[i][j] = matrix_m[i - 1][j - 1] + matching.score;
+                    matrix_t[i][j] = Entry(Direction::Diag, w);
+                }
+            }
+        }
+
+        let mut i = m;
+        let mut j = n;
+
+        let mut matchings = Matchings::from_single(
+            UnorderedPair(left, right),
+            MatchingEntry::new(left, right, matrix_m[m][n] + root_matching),
+        );
+
+        while i >= 1 && j >= 1 {
+            match matrix_t.get(i).unwrap().get(j).unwrap().0 {
+                Direction::Top => i -= 1,
+                Direction::Left => j -= 1,
+                Direction::Diag => {
+                    if matrix_m[i][j] > matrix_m[i - 1][j - 1] {
+                        matchings.extend(matrix_t[i][j].1.clone());
+                    }
+                    i -= 1;
+                    j -= 1;
+                }
+            }
+        }
+
+        matchings
+    } else {
+        Matchings::empty()
+    }
+}

--- a/matching/src/ordered/yang.rs
+++ b/matching/src/ordered/yang.rs
@@ -65,11 +65,6 @@ pub fn yang<'a>(
             Direction::Left => j -= 1,
             Direction::Diag => {
                 if matrix_m[i][j] > matrix_m[i - 1][j - 1] {
-                    log::debug!(
-                        "Assigning a match between {:?} and {:?}",
-                        left_children.get(i - 1).unwrap().contents(),
-                        right_children.get(j - 1).unwrap().contents()
-                    );
                     matchings.extend(matrix_t[i][j].1.clone());
                 }
                 i -= 1;

--- a/matching/src/ordered/yang.rs
+++ b/matching/src/ordered/yang.rs
@@ -24,6 +24,11 @@ pub fn yang<'a>(
 ) -> usize {
     let m = left_children.len();
     let n = right_children.len();
+    log::debug!(
+        "Starting Yang algorithm comparing {:?} and {:?} children",
+        m,
+        n
+    );
 
     let mut matrix_m = vec![vec![0; n + 1]; m + 1];
     let mut matrix_t = vec![vec![Entry::default(); n + 1]; m + 1];

--- a/matching/src/ordered/yang.rs
+++ b/matching/src/ordered/yang.rs
@@ -65,6 +65,11 @@ pub fn yang<'a>(
             Direction::Left => j -= 1,
             Direction::Diag => {
                 if matrix_m[i][j] > matrix_m[i - 1][j - 1] {
+                    log::debug!(
+                        "Assigning a match between {:?} and {:?}",
+                        left_children.get(i - 1).unwrap().contents(),
+                        right_children.get(j - 1).unwrap().contents()
+                    );
                     matchings.extend(matrix_t[i][j].1.clone());
                 }
                 i -= 1;

--- a/matching/src/ordered/yang.rs
+++ b/matching/src/ordered/yang.rs
@@ -1,5 +1,4 @@
-use crate::{matches::Matches, matching_entry::MatchingEntry, Matchings};
-use unordered_pair::UnorderedPair;
+use crate::Matchings;
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 enum Direction {
@@ -17,72 +16,62 @@ impl Default for Entry<'_> {
     }
 }
 
+// Returns the maximum matching between the children
 pub fn yang<'a>(
-    left: &'a model::CSTNode,
-    right: &'a model::CSTNode,
-    root_matching: usize,
-) -> Matchings<'a> {
-    if let (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) =
-        (left, right)
-    {
-        let m = nt_left.get_children().len();
-        let n = nt_right.get_children().len();
+    left_children: &'a [model::CSTNode],
+    right_children: &'a [model::CSTNode],
+    matchings: &mut Matchings<'a>,
+) -> usize {
+    let m = left_children.len();
+    let n = right_children.len();
 
-        let mut matrix_m = vec![vec![0; n + 1]; m + 1];
-        let mut matrix_t = vec![vec![Entry::default(); n + 1]; m + 1];
+    let mut matrix_m = vec![vec![0; n + 1]; m + 1];
+    let mut matrix_t = vec![vec![Entry::default(); n + 1]; m + 1];
 
-        for i in 1..m + 1 {
-            for j in 1..n + 1 {
-                let left_child = nt_left.get_children().get(i - 1).unwrap();
-                let right_child = nt_right.get_children().get(j - 1).unwrap();
+    for i in 1..m + 1 {
+        for j in 1..n + 1 {
+            let left_child = left_children.get(i - 1).unwrap();
+            let right_child = right_children.get(j - 1).unwrap();
 
-                let w = crate::calculate_matchings(left_child, right_child);
-                let matching = w
-                    .get_matching_entry(left_child, right_child)
-                    .unwrap_or_default();
+            let w = crate::calculate_matchings(left_child, right_child);
+            let matching = w
+                .get_matching_entry(left_child, right_child)
+                .unwrap_or_default();
 
-                if matrix_m[i][j - 1] > matrix_m[i - 1][j] {
-                    if matrix_m[i][j - 1] > matrix_m[i - 1][j - 1] + matching.score {
-                        matrix_m[i][j] = matrix_m[i][j - 1];
-                        matrix_t[i][j] = Entry(Direction::Left, w);
-                    } else {
-                        matrix_m[i][j] = matrix_m[i - 1][j - 1] + matching.score;
-                        matrix_t[i][j] = Entry(Direction::Diag, w);
-                    }
-                } else if matrix_m[i - 1][j] > matrix_m[i - 1][j - 1] + matching.score {
-                    matrix_m[i][j] = matrix_m[i - 1][j];
-                    matrix_t[i][j] = Entry(Direction::Top, w);
+            if matrix_m[i][j - 1] > matrix_m[i - 1][j] {
+                if matrix_m[i][j - 1] > matrix_m[i - 1][j - 1] + matching.score {
+                    matrix_m[i][j] = matrix_m[i][j - 1];
+                    matrix_t[i][j] = Entry(Direction::Left, w);
                 } else {
                     matrix_m[i][j] = matrix_m[i - 1][j - 1] + matching.score;
                     matrix_t[i][j] = Entry(Direction::Diag, w);
                 }
+            } else if matrix_m[i - 1][j] > matrix_m[i - 1][j - 1] + matching.score {
+                matrix_m[i][j] = matrix_m[i - 1][j];
+                matrix_t[i][j] = Entry(Direction::Top, w);
+            } else {
+                matrix_m[i][j] = matrix_m[i - 1][j - 1] + matching.score;
+                matrix_t[i][j] = Entry(Direction::Diag, w);
             }
         }
-
-        let mut i = m;
-        let mut j = n;
-
-        let mut matchings = Matchings::from_single(
-            UnorderedPair(left, right),
-            MatchingEntry::new(left, right, matrix_m[m][n] + root_matching),
-        );
-
-        while i >= 1 && j >= 1 {
-            match matrix_t.get(i).unwrap().get(j).unwrap().0 {
-                Direction::Top => i -= 1,
-                Direction::Left => j -= 1,
-                Direction::Diag => {
-                    if matrix_m[i][j] > matrix_m[i - 1][j - 1] {
-                        matchings.extend(matrix_t[i][j].1.clone());
-                    }
-                    i -= 1;
-                    j -= 1;
-                }
-            }
-        }
-
-        matchings
-    } else {
-        Matchings::empty()
     }
+
+    let mut i = m;
+    let mut j = n;
+
+    while i >= 1 && j >= 1 {
+        match matrix_t.get(i).unwrap().get(j).unwrap().0 {
+            Direction::Top => i -= 1,
+            Direction::Left => j -= 1,
+            Direction::Diag => {
+                if matrix_m[i][j] > matrix_m[i - 1][j - 1] {
+                    matchings.extend(matrix_t[i][j].1.clone());
+                }
+                i -= 1;
+                j -= 1;
+            }
+        }
+    }
+
+    matrix_m[m][n]
 }

--- a/parsing/src/parse.rs
+++ b/parsing/src/parse.rs
@@ -30,8 +30,6 @@ fn explore_node<'a>(node: Node, src: &'a str, config: &'a ParserConfiguration) -
             .get(node.kind())
             .and_then(|extractor| extractor.extract_identifier_from_node(node, src));
 
-        log::debug!("Passing over node {:?}", node);
-
         if let Some(ref identifier) = identifier {
             log::debug!("Found identifier {:?} for node {:?}", identifier, node);
         }


### PR DESCRIPTION
This PR optimizes Yang-based tree matching by detecting identical child sequences before running the full dynamic programming algorithm.

### Changes
- Added a recursive identical subtree matcher (inspired on jDime) that:
  - verifies nodes and descendants match exactly,
  - builds the corresponding `MatchingEntry`s directly,
  - avoids invoking Yang when the optimal matching is already known.
- Added common prefix/suffix detection for child lists, allowing Yang to operate only on the unmatched middle region.
- Optimized `Matchings` construction and extension to avoid intermediate `HashMap` allocations.

### Motivation
Yang's dynamic programming phase evaluates all child-pair combinations, even when trees are already identical. For unchanged code regions, this introduced unnecessary recursive matching and matrix construction overhead.

The new fast path preserves Yang's scoring semantics while skipping DP computation whenever a perfect ordered matching can be proven.

### Performance impact
This optimization is most effective when changes are localized and large common prefixes or suffixes exist between child lists. In these cases, the Yang dynamic programming matrix is built only for the unmatched middle region.

For example, a tree with 1000 children where the first and last 250 children are identical only requires Yang to process the remaining 500 children, reducing the search space significantly.

For trees with small identical regions (e.g., only 10 matching children at the beginning and end of a 1000-child list), the reduction is smaller, as Yang still processes most of the original input. For completely different trees, the additional identical matching checks introduce only a small overhead before falling back to the original algorithm.

However, this optimization improves the general case because source code changes are typically localized: most subtrees remain unchanged while only a small portion of the tree is modified. These unchanged regions can now be identified using a linear scan instead of repeatedly evaluating all possible child pair combinations through Yang's quadratic dynamic programming algorithm.