### PR TITLE
refactor: Separate matching orchestration from ordered/unordered matching algorithms

### DIFF
--- a/matching/src/calculate.rs
+++ b/matching/src/calculate.rs
@@ -9,8 +9,9 @@ pub fn calculate_matchings<'a>(
         return matchings;
     }
 
-    let score = calculate_subtree_matching(left, right, &mut matchings);
-    matchings.push(left, right, score);
+    let subtrees_matching = calculate_subtree_matching(left, right, &mut matchings);
+    let root_matching = 1;
+    matchings.push(left, right, root_matching + subtrees_matching);
 
     matchings
 }
@@ -23,12 +24,12 @@ fn calculate_subtree_matching<'a>(
     match (left, right) {
         (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) => {
             if nt_left.are_children_unordered && nt_right.are_children_unordered {
-                1 + unordered::calculate_subtree_matching(nt_left, nt_right, matchings)
+                unordered::calculate_subtree_matching(nt_left, nt_right, matchings)
             } else {
-                1 + ordered::calculate_subtree_matching(nt_left, nt_right, matchings)
+                ordered::calculate_subtree_matching(nt_left, nt_right, matchings)
             }
         }
-        (model::CSTNode::Terminal(_), model::CSTNode::Terminal(_)) => 1,
+        (model::CSTNode::Terminal(_), model::CSTNode::Terminal(_)) => 0,
         _ => unreachable!("can_match guarantees both nodes have the same variant"),
     }
 }

--- a/matching/src/calculate.rs
+++ b/matching/src/calculate.rs
@@ -1,0 +1,66 @@
+use crate::{Matchings, can_match::CanMatch, ordered, unordered};
+
+pub fn calculate_matchings<'a>(
+    left: &'a model::CSTNode,
+    right: &'a model::CSTNode,
+) -> Matchings<'a> {
+    let mut matchings = Matchings::with_capacity(left.get_tree_size().max(right.get_tree_size()));
+    if !left.can_match(right) {
+        return matchings;
+    }
+
+    let score = calculate_subtree_matching(left, right, &mut matchings);
+    matchings.push(left, right, score);
+
+    matchings
+}
+
+fn calculate_subtree_matching<'a>(
+    left: &'a model::CSTNode<'a>,
+    right: &'a model::CSTNode<'a>,
+    matchings: &mut Matchings<'a>,
+) -> usize {
+    match (left, right) {
+        (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) => {
+            if nt_left.are_children_unordered && nt_right.are_children_unordered {
+                1 + unordered::calculate_subtree_matching(nt_left, nt_right, matchings)
+            } else {
+                1 + ordered::calculate_subtree_matching(nt_left, nt_right, matchings)
+            }
+        }
+        (model::CSTNode::Terminal(_), model::CSTNode::Terminal(_)) => 1,
+        _ => unreachable!("can_match guarantees both nodes have the same variant"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::calculate_matchings;
+    use model::{cst_node::Terminal, CSTNode, Point};
+
+    #[test]
+    fn two_terminal_nodes_matches_with_a_score_of_one_if_they_have_the_same_kind_and_value() {
+        let left = CSTNode::Terminal(Terminal {
+            id: uuid::Uuid::new_v4(),
+            kind: "kind",
+            value: "value",
+            start_position: Point { row: 0, column: 0 },
+            end_position: Point { row: 0, column: 5 },
+            leading_white_space: None,
+        });
+        let right = CSTNode::Terminal(Terminal {
+            id: uuid::Uuid::new_v4(),
+            kind: "kind",
+            value: "value",
+            start_position: Point { row: 0, column: 0 },
+            end_position: Point { row: 0, column: 5 },
+            leading_white_space: None,
+        });
+
+        let matchings = calculate_matchings(&left, &right);
+
+        let left_right_matching = matchings.get_matching_entry(&left, &right).unwrap();
+        assert_eq!(1, left_right_matching.score);
+        assert!(left_right_matching.is_perfect_match);
+    }
+}

--- a/matching/src/calculate.rs
+++ b/matching/src/calculate.rs
@@ -1,4 +1,4 @@
-use crate::{Matchings, can_match::CanMatch, ordered, unordered};
+use crate::{can_match::CanMatch, ordered, unordered, Matchings};
 
 pub fn calculate_matchings<'a>(
     left: &'a model::CSTNode,

--- a/matching/src/can_match.rs
+++ b/matching/src/can_match.rs
@@ -1,12 +1,12 @@
 use model::CSTNode;
 
-pub trait Matches {
-    fn matches(&self, right: &CSTNode) -> bool;
+pub trait CanMatch {
+    fn can_match(&self, other: &Self) -> bool;
 }
 
-impl Matches for CSTNode<'_> {
-    fn matches(&self, right: &CSTNode) -> bool {
-        match (self, right) {
+impl CanMatch for CSTNode<'_> {
+    fn can_match(&self, other: &CSTNode) -> bool {
+        match (self, other) {
             (CSTNode::Terminal(left), CSTNode::Terminal(right)) => {
                 left.get_identifier() == right.get_identifier()
             }

--- a/matching/src/lib.rs
+++ b/matching/src/lib.rs
@@ -30,14 +30,14 @@ fn calculate_matchings_internal<'a>(
 
     match (left, right) {
         (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) => {
-            if nt_left.are_children_unordered && nt_right.are_children_unordered {
-                unordered::calculate_matchings(left, right, matchings)
-            } else {
-                let children_matching_score =
-                    ordered::calculate_matchings(nt_left, nt_right, matchings);
-                matchings.push(left, right, 1 + children_matching_score);
-                1 + children_matching_score
-            }
+            let children_matching_score =
+                if nt_left.are_children_unordered && nt_right.are_children_unordered {
+                    unordered::calculate_matchings(nt_left, nt_right, matchings)
+                } else {
+                    ordered::calculate_matchings(nt_left, nt_right, matchings)
+                };
+            matchings.push(left, right, 1 + children_matching_score);
+            1 + children_matching_score
         }
         (
             model::CSTNode::Terminal(model::cst_node::Terminal {

--- a/matching/src/lib.rs
+++ b/matching/src/lib.rs
@@ -1,11 +1,11 @@
-mod matches;
+mod can_match;
 mod matching;
 mod matching_entry;
 mod matchings;
 mod ordered;
 mod unordered;
 
-use matches::Matches;
+use can_match::CanMatch;
 pub use matching_entry::MatchingEntry;
 pub use matchings::Matchings;
 
@@ -15,7 +15,7 @@ pub fn calculate_matchings<'a>(
 ) -> Matchings<'a> {
     let largest_tree = left.get_tree_size().max(right.get_tree_size());
     let mut matchings = Matchings::with_capacity(largest_tree);
-    if left.matches(right) {
+    if left.can_match(right) {
         if let Some(matching_score) = calculate_matchings_internal(left, right, &mut matchings) {
             matchings.push(left, right, matching_score);
         }

--- a/matching/src/lib.rs
+++ b/matching/src/lib.rs
@@ -2,8 +2,8 @@ mod matches;
 mod matching;
 mod matching_entry;
 mod matchings;
-pub mod ordered;
-pub mod unordered;
+mod ordered;
+mod unordered;
 
 use matches::Matches;
 pub use matching_entry::MatchingEntry;
@@ -19,7 +19,7 @@ pub fn calculate_matchings<'a>(
     matchings
 }
 
-pub fn calculate_matchings_internal<'a>(
+fn calculate_matchings_internal<'a>(
     left: &'a model::CSTNode<'a>,
     right: &'a model::CSTNode<'a>,
     matchings: &mut Matchings<'a>,

--- a/matching/src/lib.rs
+++ b/matching/src/lib.rs
@@ -8,7 +8,6 @@ pub mod unordered;
 use matches::Matches;
 pub use matching_entry::MatchingEntry;
 pub use matchings::Matchings;
-use unordered_pair::UnorderedPair;
 
 pub fn calculate_matchings<'a>(
     left: &'a model::CSTNode,
@@ -43,10 +42,7 @@ pub fn calculate_matchings<'a>(
             }),
         ) => {
             let is_perfect_match = kind_left == kind_right && value_left == value_right;
-            Matchings::from_single(
-                UnorderedPair(left, right),
-                MatchingEntry::new(left, right, is_perfect_match.into()),
-            )
+            Matchings::from_single(left, right, is_perfect_match.into())
         }
         (_, _) => Matchings::empty(),
     }

--- a/matching/src/lib.rs
+++ b/matching/src/lib.rs
@@ -1,3 +1,4 @@
+mod calculate;
 mod can_match;
 mod matching;
 mod matching_entry;
@@ -5,70 +6,6 @@ mod matchings;
 mod ordered;
 mod unordered;
 
-use can_match::CanMatch;
+pub use calculate::calculate_matchings;
 pub use matching_entry::MatchingEntry;
 pub use matchings::Matchings;
-
-pub fn calculate_matchings<'a>(
-    left: &'a model::CSTNode,
-    right: &'a model::CSTNode,
-) -> Matchings<'a> {
-    let largest_tree = left.get_tree_size().max(right.get_tree_size());
-    let mut matchings = Matchings::with_capacity(largest_tree);
-    if left.can_match(right) {
-        if let Some(matching_score) = calculate_matchings_internal(left, right, &mut matchings) {
-            matchings.push(left, right, matching_score);
-        }
-    }
-    matchings
-}
-
-fn calculate_matchings_internal<'a>(
-    left: &'a model::CSTNode<'a>,
-    right: &'a model::CSTNode<'a>,
-    matchings: &mut Matchings<'a>,
-) -> Option<usize> {
-    match (left, right) {
-        (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) => {
-            if nt_left.are_children_unordered && nt_right.are_children_unordered {
-                Some(1 + unordered::calculate_matchings(nt_left, nt_right, matchings))
-            } else {
-                Some(1 + ordered::calculate_matchings(nt_left, nt_right, matchings))
-            }
-        }
-        (model::CSTNode::Terminal(_), model::CSTNode::Terminal(_)) => Some(1),
-        (_, _) => None,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::calculate_matchings;
-    use model::{cst_node::Terminal, CSTNode, Point};
-
-    #[test]
-    fn two_terminal_nodes_matches_with_a_score_of_one_if_they_have_the_same_kind_and_value() {
-        let left = CSTNode::Terminal(Terminal {
-            id: uuid::Uuid::new_v4(),
-            kind: "kind",
-            value: "value",
-            start_position: Point { row: 0, column: 0 },
-            end_position: Point { row: 0, column: 5 },
-            leading_white_space: None,
-        });
-        let right = CSTNode::Terminal(Terminal {
-            id: uuid::Uuid::new_v4(),
-            kind: "kind",
-            value: "value",
-            start_position: Point { row: 0, column: 0 },
-            end_position: Point { row: 0, column: 5 },
-            leading_white_space: None,
-        });
-
-        let matchings = calculate_matchings(&left, &right);
-
-        let left_right_matching = matchings.get_matching_entry(&left, &right).unwrap();
-        assert_eq!(1, left_right_matching.score);
-        assert!(left_right_matching.is_perfect_match);
-    }
-}

--- a/matching/src/lib.rs
+++ b/matching/src/lib.rs
@@ -13,8 +13,19 @@ pub fn calculate_matchings<'a>(
     left: &'a model::CSTNode,
     right: &'a model::CSTNode,
 ) -> Matchings<'a> {
+    let largest_tree = left.get_tree_size().max(right.get_tree_size());
+    let mut matchings = Matchings::with_capacity(largest_tree);
+    calculate_matchings_internal(left, right, &mut matchings);
+    matchings
+}
+
+pub fn calculate_matchings_internal<'a>(
+    left: &'a model::CSTNode<'a>,
+    right: &'a model::CSTNode<'a>,
+    matchings: &mut Matchings<'a>,
+) -> usize {
     if !left.matches(right) {
-        return Matchings::empty();
+        return 0;
     }
 
     match (left, right) {
@@ -24,9 +35,9 @@ pub fn calculate_matchings<'a>(
         ) => {
             if non_terminal_left.are_children_unordered && non_terminal_right.are_children_unordered
             {
-                unordered::calculate_matchings(left, right)
+                unordered::calculate_matchings(left, right, matchings)
             } else {
-                ordered::calculate_matchings(left, right)
+                ordered::calculate_matchings(left, right, matchings)
             }
         }
         (
@@ -41,10 +52,11 @@ pub fn calculate_matchings<'a>(
                 ..
             }),
         ) => {
-            let is_perfect_match = kind_left == kind_right && value_left == value_right;
-            Matchings::from_single(left, right, is_perfect_match.into())
+            let score: usize = (kind_left == kind_right && value_left == value_right).into();
+            matchings.push(left, right, score);
+            score
         }
-        (_, _) => Matchings::empty(),
+        (_, _) => 0,
     }
 }
 

--- a/matching/src/lib.rs
+++ b/matching/src/lib.rs
@@ -29,15 +29,14 @@ fn calculate_matchings_internal<'a>(
     }
 
     match (left, right) {
-        (
-            model::CSTNode::NonTerminal(non_terminal_left),
-            model::CSTNode::NonTerminal(non_terminal_right),
-        ) => {
-            if non_terminal_left.are_children_unordered && non_terminal_right.are_children_unordered
-            {
+        (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) => {
+            if nt_left.are_children_unordered && nt_right.are_children_unordered {
                 unordered::calculate_matchings(left, right, matchings)
             } else {
-                ordered::calculate_matchings(left, right, matchings)
+                let children_matching_score =
+                    ordered::calculate_matchings(nt_left, nt_right, matchings);
+                matchings.push(left, right, 1 + children_matching_score);
+                1 + children_matching_score
             }
         }
         (

--- a/matching/src/lib.rs
+++ b/matching/src/lib.rs
@@ -15,7 +15,11 @@ pub fn calculate_matchings<'a>(
 ) -> Matchings<'a> {
     let largest_tree = left.get_tree_size().max(right.get_tree_size());
     let mut matchings = Matchings::with_capacity(largest_tree);
-    calculate_matchings_internal(left, right, &mut matchings);
+    if left.matches(right) {
+        if let Some(matching_score) = calculate_matchings_internal(left, right, &mut matchings) {
+            matchings.push(left, right, matching_score);
+        }
+    }
     matchings
 }
 
@@ -23,39 +27,17 @@ fn calculate_matchings_internal<'a>(
     left: &'a model::CSTNode<'a>,
     right: &'a model::CSTNode<'a>,
     matchings: &mut Matchings<'a>,
-) -> usize {
-    if !left.matches(right) {
-        return 0;
-    }
-
+) -> Option<usize> {
     match (left, right) {
         (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) => {
-            let children_matching_score =
-                if nt_left.are_children_unordered && nt_right.are_children_unordered {
-                    unordered::calculate_matchings(nt_left, nt_right, matchings)
-                } else {
-                    ordered::calculate_matchings(nt_left, nt_right, matchings)
-                };
-            matchings.push(left, right, 1 + children_matching_score);
-            1 + children_matching_score
+            if nt_left.are_children_unordered && nt_right.are_children_unordered {
+                Some(1 + unordered::calculate_matchings(nt_left, nt_right, matchings))
+            } else {
+                Some(1 + ordered::calculate_matchings(nt_left, nt_right, matchings))
+            }
         }
-        (
-            model::CSTNode::Terminal(model::cst_node::Terminal {
-                kind: kind_left,
-                value: value_left,
-                ..
-            }),
-            model::CSTNode::Terminal(model::cst_node::Terminal {
-                kind: kind_right,
-                value: value_right,
-                ..
-            }),
-        ) => {
-            let score: usize = (kind_left == kind_right && value_left == value_right).into();
-            matchings.push(left, right, score);
-            score
-        }
-        (_, _) => 0,
+        (model::CSTNode::Terminal(_), model::CSTNode::Terminal(_)) => Some(1),
+        (_, _) => None,
     }
 }
 

--- a/matching/src/matchings.rs
+++ b/matching/src/matchings.rs
@@ -78,7 +78,7 @@ impl<'a> Matchings<'a> {
         }
     }
 
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.matching_entries.len()
     }
 

--- a/matching/src/matchings.rs
+++ b/matching/src/matchings.rs
@@ -82,6 +82,10 @@ impl<'a> Matchings<'a> {
         self.matching_entries.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn push(&mut self, left: &'a CSTNode<'a>, right: &'a CSTNode<'a>, score: usize) {
         if self
             .get_matching_entry(left, right)

--- a/matching/src/matchings.rs
+++ b/matching/src/matchings.rs
@@ -13,6 +13,13 @@ pub struct Matchings<'a> {
 }
 
 impl<'a> Matchings<'a> {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Matchings {
+            matching_entries: HashMap::with_capacity(capacity),
+            individual_matchings: HashMap::with_capacity(capacity * 2),
+        }
+    }
+
     pub fn empty() -> Self {
         Matchings {
             matching_entries: HashMap::new(),

--- a/matching/src/matchings.rs
+++ b/matching/src/matchings.rs
@@ -87,11 +87,11 @@ impl<'a> Matchings<'a> {
     }
 
     pub fn push(&mut self, left: &'a CSTNode<'a>, right: &'a CSTNode<'a>, score: usize) {
-        if self
+        if let Some(existing) = self
             .get_matching_entry(left, right)
-            .is_some_and(|existing| existing.score > score)
+            .filter(|existing| existing.score > score)
         {
-            log::debug!("Early returning because a matching with higher score already exists");
+            log::debug!("Early returning because a matching with higher score ({:?} vs {:?}) already exists for {:?} and {:?}", existing.score, score, left.contents(), right.contents());
         } else {
             self.individual_matchings.insert(left, right);
             self.individual_matchings.insert(right, left);

--- a/matching/src/matchings.rs
+++ b/matching/src/matchings.rs
@@ -20,21 +20,25 @@ impl<'a> Matchings<'a> {
         }
     }
 
-    pub fn from_single(key: UnorderedPair<&'a CSTNode>, value: MatchingEntry) -> Self {
+    pub fn from_single(left: &'a CSTNode<'a>, right: &'a CSTNode<'a>, score: usize) -> Self {
         Matchings {
-            matching_entries: HashMap::from([(key, value)]),
-            individual_matchings: HashMap::from([(key.0, key.1), (key.1, key.0)]),
+            matching_entries: HashMap::from([(
+                UnorderedPair(left, right),
+                MatchingEntry::new(left, right, score),
+            )]),
+            individual_matchings: HashMap::from([(left, right), (right, left)]),
         }
     }
 
     pub fn new(matching_entries: HashMap<UnorderedPair<&'a CSTNode<'a>>, MatchingEntry>) -> Self {
+        let mut individual_matchings = HashMap::with_capacity(matching_entries.len() * 2);
+        for key in matching_entries.keys() {
+            individual_matchings.insert(key.0, key.1);
+            individual_matchings.insert(key.1, key.0);
+        }
+
         Matchings {
-            individual_matchings: {
-                matching_entries
-                    .keys()
-                    .flat_map(|key| [(key.0, key.1), (key.1, key.0)])
-                    .collect::<HashMap<&'a CSTNode<'a>, &'a CSTNode<'a>>>()
-            },
+            individual_matchings,
             matching_entries,
         }
     }
@@ -60,21 +64,31 @@ impl<'a> Matchings<'a> {
     }
 
     pub fn extend(&mut self, matchings: Matchings<'a>) {
-        self.individual_matchings.extend(
-            matchings
-                .matching_entries
-                .keys()
-                .flat_map(|key| [(key.0, key.1), (key.1, key.0)])
-                .collect::<HashMap<&'a CSTNode<'a>, &'a CSTNode<'a>>>(),
-        );
-        self.matching_entries.extend(matchings);
+        self.individual_matchings.reserve(matchings.len() * 2);
+        self.matching_entries.reserve(matchings.len());
+        for (UnorderedPair(left, right), entry) in matchings.matching_entries.iter() {
+            self.push(left, right, entry.score);
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.matching_entries.len()
     }
 
     pub fn push(&mut self, left: &'a CSTNode<'a>, right: &'a CSTNode<'a>, score: usize) {
-        self.extend(Matchings::from_single(
-            UnorderedPair(left, right),
-            MatchingEntry::new(left, right, score),
-        ));
+        if self
+            .get_matching_entry(left, right)
+            .is_some_and(|existing| existing.score > score)
+        {
+            log::debug!("Early returning because a matching with higher score already exists");
+        } else {
+            self.individual_matchings.insert(left, right);
+            self.individual_matchings.insert(right, left);
+            self.matching_entries.insert(
+                UnorderedPair(left, right),
+                MatchingEntry::new(left, right, score),
+            );
+        }
     }
 }
 

--- a/matching/src/ordered/identical.rs
+++ b/matching/src/ordered/identical.rs
@@ -1,6 +1,7 @@
 use model::CSTNode;
 
 use crate::{matches::Matches, Matchings};
+
 pub fn identical_matches<'a>(
     left_children: &'a [CSTNode<'a>],
     right_children: &'a [CSTNode<'a>],

--- a/matching/src/ordered/identical.rs
+++ b/matching/src/ordered/identical.rs
@@ -1,6 +1,6 @@
 use model::CSTNode;
 
-use crate::{matches::Matches, Matchings};
+use crate::{can_match::CanMatch, Matchings};
 
 pub fn identical_matches<'a>(
     left_children: &'a [CSTNode<'a>],
@@ -50,7 +50,7 @@ fn identical_match<'a>(
     right: &'a CSTNode<'a>,
     matchings: &mut Matchings<'a>,
 ) -> Option<usize> {
-    if !left.matches(right) {
+    if !left.can_match(right) {
         return None;
     }
 

--- a/matching/src/ordered/mod.rs
+++ b/matching/src/ordered/mod.rs
@@ -5,7 +5,7 @@ use model::cst_node::NonTerminal;
 
 use crate::Matchings;
 
-pub fn calculate_matchings<'a>(
+pub fn calculate_subtree_matching<'a>(
     left: &'a NonTerminal<'a>,
     right: &'a NonTerminal<'a>,
     matchings: &mut Matchings<'a>,
@@ -79,7 +79,7 @@ mod tests {
         };
 
         let mut matchings = Matchings::empty();
-        super::calculate_matchings(&left, &right, &mut matchings);
+        super::calculate_subtree_matching(&left, &right, &mut matchings);
 
         let child_matching = matchings.get_matching_entry(&child, &child);
         assert!(child_matching.is_some());
@@ -126,7 +126,7 @@ mod tests {
         };
 
         let mut matchings = Matchings::empty();
-        super::calculate_matchings(&left, &right, &mut matchings);
+        super::calculate_subtree_matching(&left, &right, &mut matchings);
         assert!(matchings
             .get_matching_entry(&left_child, &right_child)
             .is_none())
@@ -171,7 +171,7 @@ mod tests {
         };
 
         let mut matchings = Matchings::empty();
-        let score = super::calculate_matchings(&left, &right, &mut matchings);
+        let score = super::calculate_subtree_matching(&left, &right, &mut matchings);
         assert_eq!(1, score);
     }
 
@@ -206,7 +206,7 @@ mod tests {
         };
 
         let mut matchings = Matchings::empty();
-        let score = super::calculate_matchings(&left, &right, &mut matchings);
+        let score = super::calculate_subtree_matching(&left, &right, &mut matchings);
         assert_eq!(1, score);
     }
 
@@ -251,7 +251,7 @@ mod tests {
         };
 
         let mut matchings = Matchings::empty();
-        let score = super::calculate_matchings(&left, &right, &mut matchings);
+        let score = super::calculate_subtree_matching(&left, &right, &mut matchings);
         assert_eq!(2, score);
 
         let intermediate_matching = matchings

--- a/matching/src/ordered/mod.rs
+++ b/matching/src/ordered/mod.rs
@@ -1,54 +1,42 @@
 mod identical;
 mod yang;
 
-use crate::{matches::Matches, ordered::identical::identical_matches, Matchings};
+use model::cst_node::NonTerminal;
+
+use crate::Matchings;
 
 pub fn calculate_matchings<'a>(
-    left: &'a model::CSTNode<'a>,
-    right: &'a model::CSTNode<'a>,
+    left: &'a NonTerminal<'a>,
+    right: &'a NonTerminal<'a>,
     matchings: &mut Matchings<'a>,
 ) -> usize {
-    if let (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) =
-        (left, right)
-    {
-        let root_matching: usize = (left.matches(right)).into();
+    let (prefix, suffix, identical_children_score) =
+        identical::identical_matches(left.get_children(), right.get_children(), matchings);
 
-        let (prefix, suffix, identical_children_score) =
-            identical_matches(nt_left.get_children(), nt_right.get_children(), matchings);
+    let left_children = left.get_children();
+    let right_children = right.get_children();
 
-        let left_children = nt_left.get_children();
-        let right_children = nt_right.get_children();
+    let remaining_children_left = left_children.len() - prefix - suffix;
+    let remaining_children_right = right_children.len() - prefix - suffix;
 
-        let remaining_children_left = left_children.len() - prefix - suffix;
-        let remaining_children_right = right_children.len() - prefix - suffix;
-
-        if remaining_children_left == 0 && remaining_children_right == 0 {
-            log::debug!("Identical suffix/prefix fully reduced search space");
-            matchings.push(left, right, identical_children_score + root_matching);
-            identical_children_score + root_matching
-        } else {
-            log::debug!(
-                "Identical suffix/prefix reduced search space from {:?}x{:?} to {:?}x{:?}",
-                left_children.len(),
-                right_children.len(),
-                remaining_children_left,
-                remaining_children_right,
-            );
-
-            let maximum_children_score = yang::yang(
-                left_children[prefix..left_children.len() - suffix].as_ref(),
-                right_children[prefix..right_children.len() - suffix].as_ref(),
-                matchings,
-            );
-            matchings.push(
-                left,
-                right,
-                identical_children_score + maximum_children_score + root_matching,
-            );
-            identical_children_score + maximum_children_score + root_matching
-        }
+    if remaining_children_left == 0 && remaining_children_right == 0 {
+        log::debug!("Identical suffix/prefix fully reduced search space");
+        identical_children_score
     } else {
-        0
+        log::debug!(
+            "Identical suffix/prefix reduced search space from {:?}x{:?} to {:?}x{:?}",
+            left_children.len(),
+            right_children.len(),
+            remaining_children_left,
+            remaining_children_right,
+        );
+
+        let maximum_children_score = yang::yang(
+            left_children[prefix..left_children.len() - suffix].as_ref(),
+            right_children[prefix..right_children.len() - suffix].as_ref(),
+            matchings,
+        );
+        identical_children_score + maximum_children_score
     }
 }
 
@@ -71,7 +59,7 @@ mod tests {
             end_position: Point { row: 1, column: 7 },
             leading_white_space: None,
         });
-        let left = CSTNode::NonTerminal(NonTerminal {
+        let left = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "kind_a",
             are_children_unordered: false,
@@ -79,8 +67,8 @@ mod tests {
             end_position: Point { row: 1, column: 7 },
             children: vec![child.clone()],
             ..Default::default()
-        });
-        let right = CSTNode::NonTerminal(NonTerminal {
+        };
+        let right = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "kind_a",
             are_children_unordered: false,
@@ -88,7 +76,7 @@ mod tests {
             end_position: Point { row: 1, column: 7 },
             children: vec![child.clone()],
             ..Default::default()
-        });
+        };
 
         let mut matchings = Matchings::empty();
         super::calculate_matchings(&left, &right, &mut matchings);
@@ -118,7 +106,7 @@ mod tests {
             leading_white_space: None,
         });
 
-        let left = CSTNode::NonTerminal(NonTerminal {
+        let left = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "kind_a",
             are_children_unordered: false,
@@ -126,8 +114,8 @@ mod tests {
             start_position: Point { row: 1, column: 0 },
             end_position: Point { row: 0, column: 7 },
             ..Default::default()
-        });
-        let right = CSTNode::NonTerminal(NonTerminal {
+        };
+        let right = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "kind_a",
             are_children_unordered: false,
@@ -135,7 +123,7 @@ mod tests {
             start_position: Point { row: 1, column: 0 },
             end_position: Point { row: 0, column: 7 },
             ..Default::default()
-        });
+        };
 
         let mut matchings = Matchings::empty();
         super::calculate_matchings(&left, &right, &mut matchings);
@@ -145,7 +133,7 @@ mod tests {
     }
 
     #[test]
-    fn the_matching_between_two_subtrees_is_the_sum_of_the_matchings_plus_the_root() {
+    fn the_matching_between_two_subtrees_is_the_sum_of_the_matchings() {
         let common_child = CSTNode::Terminal(Terminal {
             id: uuid::Uuid::new_v4(),
             kind: "kind_b",
@@ -163,7 +151,7 @@ mod tests {
             leading_white_space: None,
         });
 
-        let left = CSTNode::NonTerminal(NonTerminal {
+        let left = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "kind_a",
             are_children_unordered: false,
@@ -171,8 +159,8 @@ mod tests {
             end_position: Point { row: 0, column: 7 },
             children: vec![common_child.clone()],
             ..Default::default()
-        });
-        let right = CSTNode::NonTerminal(NonTerminal {
+        };
+        let right = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "kind_a",
             are_children_unordered: false,
@@ -180,15 +168,11 @@ mod tests {
             end_position: Point { row: 0, column: 7 },
             children: vec![common_child.clone(), unique_right_child],
             ..Default::default()
-        });
+        };
 
         let mut matchings = Matchings::empty();
         let score = super::calculate_matchings(&left, &right, &mut matchings);
-
-        let left_right_matchings = matchings.get_matching_entry(&left, &right).unwrap();
-        assert_eq!(2, score);
-        assert_eq!(score, left_right_matchings.score);
-        assert!(!left_right_matchings.is_perfect_match);
+        assert_eq!(1, score);
     }
 
     #[test]
@@ -202,7 +186,7 @@ mod tests {
             leading_white_space: None,
         });
 
-        let left = CSTNode::NonTerminal(NonTerminal {
+        let left = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "kind_a",
             are_children_unordered: false,
@@ -210,8 +194,8 @@ mod tests {
             end_position: Point { row: 0, column: 7 },
             children: vec![common_child.clone()],
             ..Default::default()
-        });
-        let right = CSTNode::NonTerminal(NonTerminal {
+        };
+        let right = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "kind_a",
             are_children_unordered: false,
@@ -219,15 +203,11 @@ mod tests {
             end_position: Point { row: 0, column: 7 },
             children: vec![common_child.clone()],
             ..Default::default()
-        });
+        };
 
         let mut matchings = Matchings::empty();
         let score = super::calculate_matchings(&left, &right, &mut matchings);
-
-        let left_right_matchings = matchings.get_matching_entry(&left, &right).unwrap();
-        assert_eq!(2, score);
-        assert_eq!(score, left_right_matchings.score);
-        assert!(left_right_matchings.is_perfect_match);
+        assert_eq!(1, score);
     }
 
     #[test]
@@ -251,7 +231,7 @@ mod tests {
             ..Default::default()
         });
 
-        let left = CSTNode::NonTerminal(NonTerminal {
+        let left = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "kind_a",
             are_children_unordered: false,
@@ -259,8 +239,8 @@ mod tests {
             end_position: Point { row: 0, column: 7 },
             children: vec![intermediate.clone()],
             ..Default::default()
-        });
-        let right = CSTNode::NonTerminal(NonTerminal {
+        };
+        let right = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "kind_a",
             are_children_unordered: false,
@@ -268,20 +248,16 @@ mod tests {
             end_position: Point { row: 0, column: 7 },
             children: vec![intermediate.clone()],
             ..Default::default()
-        });
+        };
 
         let mut matchings = Matchings::empty();
         let score = super::calculate_matchings(&left, &right, &mut matchings);
+        assert_eq!(2, score);
 
         let intermediate_matching = matchings
             .get_matching_entry(&intermediate, &intermediate)
             .unwrap();
         assert_eq!(2, intermediate_matching.score);
         assert!(intermediate_matching.is_perfect_match);
-
-        let left_right_matching = matchings.get_matching_entry(&left, &right).unwrap();
-        assert_eq!(3, score);
-        assert_eq!(score, left_right_matching.score);
-        assert!(left_right_matching.is_perfect_match);
     }
 }

--- a/matching/src/ordered/mod.rs
+++ b/matching/src/ordered/mod.rs
@@ -4,20 +4,17 @@ mod yang;
 use crate::{matches::Matches, ordered::identical::identical_matches, Matchings};
 
 pub fn calculate_matchings<'a>(
-    left: &'a model::CSTNode,
-    right: &'a model::CSTNode,
-) -> Matchings<'a> {
+    left: &'a model::CSTNode<'a>,
+    right: &'a model::CSTNode<'a>,
+    matchings: &mut Matchings<'a>,
+) -> usize {
     if let (model::CSTNode::NonTerminal(nt_left), model::CSTNode::NonTerminal(nt_right)) =
         (left, right)
     {
         let root_matching: usize = (left.matches(right)).into();
-        let mut matchings: Matchings<'_> = Matchings::empty();
 
-        let (prefix, suffix, identical_children_score) = identical_matches(
-            nt_left.get_children(),
-            nt_right.get_children(),
-            &mut matchings,
-        );
+        let (prefix, suffix, identical_children_score) =
+            identical_matches(nt_left.get_children(), nt_right.get_children(), matchings);
 
         let left_children = nt_left.get_children();
         let right_children = nt_right.get_children();
@@ -28,6 +25,7 @@ pub fn calculate_matchings<'a>(
         if remaining_children_left == 0 && remaining_children_right == 0 {
             log::debug!("Identical suffix/prefix fully reduced search space");
             matchings.push(left, right, identical_children_score + root_matching);
+            identical_children_score + root_matching
         } else {
             log::debug!(
                 "Identical suffix/prefix reduced search space from {:?}x{:?} to {:?}x{:?}",
@@ -40,17 +38,17 @@ pub fn calculate_matchings<'a>(
             let maximum_children_score = yang::yang(
                 left_children[prefix..left_children.len() - suffix].as_ref(),
                 right_children[prefix..right_children.len() - suffix].as_ref(),
-                &mut matchings,
+                matchings,
             );
             matchings.push(
                 left,
                 right,
                 identical_children_score + maximum_children_score + root_matching,
             );
+            identical_children_score + maximum_children_score + root_matching
         }
-        matchings
     } else {
-        Matchings::empty()
+        0
     }
 }
 

--- a/matching/src/ordered/mod.rs
+++ b/matching/src/ordered/mod.rs
@@ -59,6 +59,8 @@ mod tests {
         CSTNode, Point,
     };
 
+    use crate::Matchings;
+
     #[test]
     fn it_matches_deep_nodes_as_well() {
         let child = CSTNode::Terminal(Terminal {
@@ -88,7 +90,8 @@ mod tests {
             ..Default::default()
         });
 
-        let matchings = super::calculate_matchings(&left, &right);
+        let mut matchings = Matchings::empty();
+        super::calculate_matchings(&left, &right, &mut matchings);
 
         let child_matching = matchings.get_matching_entry(&child, &child);
         assert!(child_matching.is_some());
@@ -134,7 +137,8 @@ mod tests {
             ..Default::default()
         });
 
-        let matchings = super::calculate_matchings(&left, &right);
+        let mut matchings = Matchings::empty();
+        super::calculate_matchings(&left, &right, &mut matchings);
         assert!(matchings
             .get_matching_entry(&left_child, &right_child)
             .is_none())
@@ -178,10 +182,12 @@ mod tests {
             ..Default::default()
         });
 
-        let matchings = super::calculate_matchings(&left, &right);
+        let mut matchings = Matchings::empty();
+        let score = super::calculate_matchings(&left, &right, &mut matchings);
 
         let left_right_matchings = matchings.get_matching_entry(&left, &right).unwrap();
-        assert_eq!(2, left_right_matchings.score);
+        assert_eq!(2, score);
+        assert_eq!(score, left_right_matchings.score);
         assert!(!left_right_matchings.is_perfect_match);
     }
 
@@ -215,10 +221,12 @@ mod tests {
             ..Default::default()
         });
 
-        let matchings = super::calculate_matchings(&left, &right);
+        let mut matchings = Matchings::empty();
+        let score = super::calculate_matchings(&left, &right, &mut matchings);
 
         let left_right_matchings = matchings.get_matching_entry(&left, &right).unwrap();
-        assert_eq!(2, left_right_matchings.score);
+        assert_eq!(2, score);
+        assert_eq!(score, left_right_matchings.score);
         assert!(left_right_matchings.is_perfect_match);
     }
 
@@ -262,7 +270,8 @@ mod tests {
             ..Default::default()
         });
 
-        let matchings = super::calculate_matchings(&left, &right);
+        let mut matchings = Matchings::empty();
+        let score = super::calculate_matchings(&left, &right, &mut matchings);
 
         let intermediate_matching = matchings
             .get_matching_entry(&intermediate, &intermediate)
@@ -271,7 +280,8 @@ mod tests {
         assert!(intermediate_matching.is_perfect_match);
 
         let left_right_matching = matchings.get_matching_entry(&left, &right).unwrap();
-        assert_eq!(3, left_right_matching.score);
+        assert_eq!(3, score);
+        assert_eq!(score, left_right_matching.score);
         assert!(left_right_matching.is_perfect_match);
     }
 }

--- a/matching/src/unordered/assignment_problem.rs
+++ b/matching/src/unordered/assignment_problem.rs
@@ -1,9 +1,8 @@
 use std::cmp::max;
 
 use pathfinding::{kuhn_munkres::Weights, matrix};
-use unordered_pair::UnorderedPair;
 
-use crate::{matches::Matches, MatchingEntry, Matchings};
+use crate::{matches::Matches, Matchings};
 
 pub fn calculate_matchings_for_children<'a>(
     left: &'a model::CSTNode<'a>,
@@ -41,18 +40,12 @@ fn solve_assignment_problem<'a>(
 ) -> Matchings<'a> {
     let m = children_matchings.len();
     if m == 0 {
-        return Matchings::from_single(
-            UnorderedPair(left, right),
-            MatchingEntry::new(left, right, 1),
-        );
+        return Matchings::from_single(left, right, 1);
     }
 
     let n = children_matchings[0].len();
     if n == 0 {
-        return Matchings::from_single(
-            UnorderedPair(left, right),
-            MatchingEntry::new(left, right, 1),
-        );
+        return Matchings::from_single(left, right, 1);
     }
 
     let max_size = max(m, n);
@@ -78,10 +71,7 @@ fn solve_assignment_problem<'a>(
         }
     }
 
-    result.extend(Matchings::from_single(
-        UnorderedPair(left, right),
-        MatchingEntry::new(left, right, max_matching as usize + 1),
-    ));
+    result.push(left, right, max_matching as usize + 1);
 
     result
 }

--- a/matching/src/unordered/assignment_problem.rs
+++ b/matching/src/unordered/assignment_problem.rs
@@ -2,18 +2,13 @@ use std::cmp::max;
 
 use pathfinding::{kuhn_munkres::Weights, matrix};
 
-use crate::{matches::Matches, Matchings};
+use crate::Matchings;
 
 pub fn calculate_matchings_for_children<'a>(
-    left: &'a model::CSTNode<'a>,
-    right: &'a model::CSTNode<'a>,
     left_children: &[&'a model::CSTNode<'a>],
     right_children: &[&'a model::CSTNode<'a>],
-) -> Matchings<'a> {
-    if !left.matches(right) {
-        return Matchings::empty();
-    }
-
+    matchings: &mut Matchings<'a>,
+) -> usize {
     let children_matchings = left_children
         .iter()
         .map(|left_child| {
@@ -30,22 +25,21 @@ pub fn calculate_matchings_for_children<'a>(
         })
         .collect();
 
-    solve_assignment_problem(left, right, children_matchings)
+    solve_assignment_problem(children_matchings, matchings)
 }
 
 fn solve_assignment_problem<'a>(
-    left: &'a model::CSTNode,
-    right: &'a model::CSTNode,
     children_matchings: Vec<Vec<(usize, Matchings<'a>)>>,
-) -> Matchings<'a> {
+    matchings: &mut Matchings<'a>,
+) -> usize {
     let m = children_matchings.len();
     if m == 0 {
-        return Matchings::from_single(left, right, 1);
+        return 1;
     }
 
     let n = children_matchings[0].len();
     if n == 0 {
-        return Matchings::from_single(left, right, 1);
+        return 1;
     }
 
     let max_size = max(m, n);
@@ -61,17 +55,13 @@ fn solve_assignment_problem<'a>(
         .expect("Could not build weights matrix for assignment problem.");
     let (max_matching, best_matches) = pathfinding::kuhn_munkres::kuhn_munkres(&weights_matrix);
 
-    let mut result = Matchings::empty();
-
     for i in 0..best_matches.len() {
         let j = best_matches[i];
         let cur_matching = weights_matrix.at(i, j);
         if cur_matching > 0 {
-            result.extend(children_matchings[i][j].1.clone());
+            matchings.extend(children_matchings[i][j].1.clone());
         }
     }
 
-    result.push(left, right, max_matching as usize + 1);
-
-    result
+    max_matching as usize
 }

--- a/matching/src/unordered/mod.rs
+++ b/matching/src/unordered/mod.rs
@@ -6,7 +6,7 @@ mod assignment_problem;
 
 use crate::Matchings;
 
-pub fn calculate_matchings<'a>(
+pub fn calculate_subtree_matching<'a>(
     left: &'a NonTerminal<'a>,
     right: &'a NonTerminal<'a>,
     matchings: &mut Matchings<'a>,
@@ -303,7 +303,8 @@ mod tests {
         };
 
         let mut matchings = Matchings::empty();
-        let children_matching_score = super::calculate_matchings(&left, &right, &mut matchings);
+        let children_matching_score =
+            super::calculate_subtree_matching(&left, &right, &mut matchings);
         assert_eq!(3, children_matching_score);
     }
 }

--- a/matching/src/unordered/mod.rs
+++ b/matching/src/unordered/mod.rs
@@ -4,67 +4,51 @@ use model::cst_node::{CSTNode, Delimiters, NonTerminal};
 
 mod assignment_problem;
 
-use crate::{matches::Matches, Matchings};
+use crate::Matchings;
 
 pub fn calculate_matchings<'a>(
-    left: &'a model::CSTNode<'a>,
-    right: &'a model::CSTNode<'a>,
+    left: &'a NonTerminal<'a>,
+    right: &'a NonTerminal<'a>,
     matchings: &mut Matchings<'a>,
 ) -> usize {
-    match (left, right) {
-        (model::CSTNode::NonTerminal(left_nt), model::CSTNode::NonTerminal(right_nt)) => {
-            let root_matching: usize = left.matches(right).into();
+    log::debug!(
+        "Starting matching between {:?} and {:?} children",
+        left.get_children().len(),
+        right.get_children().len()
+    );
 
-            log::debug!(
-                "Starting matching between {:?} and {:?} children",
-                left_nt.get_children().len(),
-                right_nt.get_children().len()
-            );
+    let (label_matchings, label_score, remaining_left_children, remaining_right_children) =
+        calculate_label_matchings(left, right);
 
-            let (label_matchings, label_score, remaining_left_children, remaining_right_children) =
-                calculate_label_matchings(left_nt, right_nt);
+    matchings.extend(label_matchings);
 
-            log::debug!(
-                "After matching with label there are {:?} and {:?} remaining children",
-                remaining_left_children.len(),
-                remaining_right_children.len()
-            );
+    log::debug!(
+        "After matching with label there are {:?} and {:?} remaining children",
+        remaining_left_children.len(),
+        remaining_right_children.len()
+    );
 
-            if remaining_left_children.is_empty() && remaining_right_children.is_empty() {
-                log::debug!(
-                    "Matching children of \"{}\" with \"{}\" using unique label matching.",
-                    left.kind(),
-                    right.kind()
-                );
-                matchings.push(left, right, label_score + root_matching);
-                matchings.extend(label_matchings);
-                label_score + root_matching
-            } else {
-                log::debug!(
+    if remaining_left_children.is_empty() && remaining_right_children.is_empty() {
+        log::debug!(
+            "Matching children of \"{}\" with \"{}\" using unique label matching.",
+            left.kind,
+            right.kind
+        );
+        label_score
+    } else {
+        log::debug!(
                     "Matching children of \"{}\" with \"{}\" using hybrid unique label plus assignment problem matching.",
-                    left.kind(),
-                    right.kind()
+                    left.kind,
+                    right.kind
                 );
 
-                let assignment_matchings = assignment_problem::calculate_matchings_for_children(
-                    left,
-                    right,
-                    &remaining_left_children,
-                    &remaining_right_children,
-                );
+        let assignment_score = assignment_problem::calculate_matchings_for_children(
+            &remaining_left_children,
+            &remaining_right_children,
+            matchings,
+        );
 
-                let assignment_score = assignment_matchings
-                    .get_matching_entry(left, right)
-                    .map(|matching_entry| matching_entry.score)
-                    .unwrap_or(0);
-
-                matchings.push(left, right, label_score + assignment_score);
-                matchings.extend(label_matchings);
-                matchings.extend(assignment_matchings);
-                label_score + assignment_score
-            }
-        }
-        _ => unreachable!("Unordered matching is only supported for non-terminals."),
+        label_score + assignment_score
     }
 }
 
@@ -287,7 +271,7 @@ mod tests {
         });
         let duplicate_right_child = duplicate_left_child.clone();
 
-        let left = CSTNode::NonTerminal(NonTerminal {
+        let left = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "object",
             children: vec![
@@ -301,8 +285,8 @@ mod tests {
             identifier: None,
             leading_white_space: None,
             delimiters: None,
-        });
-        let right = CSTNode::NonTerminal(NonTerminal {
+        };
+        let right = NonTerminal {
             id: uuid::Uuid::new_v4(),
             kind: "object",
             children: vec![
@@ -316,11 +300,10 @@ mod tests {
             identifier: None,
             leading_white_space: None,
             delimiters: None,
-        });
+        };
 
         let mut matchings = Matchings::empty();
-        let root_matching_score = super::calculate_matchings(&left, &right, &mut matchings);
-        assert_eq!(4, root_matching_score);
-        assert_eq!(3, matchings.len());
+        let children_matching_score = super::calculate_matchings(&left, &right, &mut matchings);
+        assert_eq!(3, children_matching_score);
     }
 }

--- a/matching/src/unordered/mod.rs
+++ b/matching/src/unordered/mod.rs
@@ -4,12 +4,13 @@ use model::cst_node::{CSTNode, Delimiters, NonTerminal};
 
 mod assignment_problem;
 
-use crate::matches::Matches;
+use crate::{matches::Matches, Matchings};
 
 pub fn calculate_matchings<'a>(
     left: &'a model::CSTNode<'a>,
     right: &'a model::CSTNode<'a>,
-) -> crate::Matchings<'a> {
+    matchings: &mut Matchings<'a>,
+) -> usize {
     match (left, right) {
         (model::CSTNode::NonTerminal(left_nt), model::CSTNode::NonTerminal(right_nt)) => {
             let root_matching: usize = left.matches(right).into();
@@ -35,9 +36,9 @@ pub fn calculate_matchings<'a>(
                     left.kind(),
                     right.kind()
                 );
-                let mut result = label_matchings;
-                result.push(left, right, label_score + root_matching);
-                result
+                matchings.push(left, right, label_score + root_matching);
+                matchings.extend(label_matchings);
+                label_score + root_matching
             } else {
                 log::debug!(
                     "Matching children of \"{}\" with \"{}\" using hybrid unique label plus assignment problem matching.",
@@ -57,10 +58,10 @@ pub fn calculate_matchings<'a>(
                     .map(|matching_entry| matching_entry.score)
                     .unwrap_or(0);
 
-                let mut result = label_matchings;
-                result.push(left, right, label_score + assignment_score);
-                result.extend(assignment_matchings);
-                result
+                matchings.push(left, right, label_score + assignment_score);
+                matchings.extend(label_matchings);
+                matchings.extend(assignment_matchings);
+                label_score + assignment_score
             }
         }
         _ => unreachable!("Unordered matching is only supported for non-terminals."),

--- a/matching/src/unordered/mod.rs
+++ b/matching/src/unordered/mod.rs
@@ -190,7 +190,7 @@ mod tests {
         CSTNode, Point,
     };
 
-    use crate::unordered::identifier_counts;
+    use crate::{unordered::identifier_counts, Matchings};
 
     fn all_children_have_unique_identifiers(node: &NonTerminal) -> bool {
         let children: Vec<&CSTNode<'_>> = node.get_children().iter().collect();
@@ -318,10 +318,9 @@ mod tests {
             delimiters: None,
         });
 
-        let matchings = super::calculate_matchings(&left, &right);
-        let root_matching = matchings.get_matching_entry(&left, &right).unwrap();
-
-        assert_eq!(4, root_matching.score);
-        assert!(root_matching.is_perfect_match);
+        let mut matchings = Matchings::empty();
+        let root_matching_score = super::calculate_matchings(&left, &right, &mut matchings);
+        assert_eq!(4, root_matching_score);
+        assert_eq!(3, matchings.len());
     }
 }

--- a/matching/src/unordered/mod.rs
+++ b/matching/src/unordered/mod.rs
@@ -5,8 +5,6 @@ use model::cst_node::{CSTNode, Delimiters, NonTerminal};
 mod assignment_problem;
 
 use crate::matches::Matches;
-use crate::{MatchingEntry, Matchings};
-use unordered_pair::UnorderedPair;
 
 pub fn calculate_matchings<'a>(
     left: &'a model::CSTNode<'a>,
@@ -38,10 +36,7 @@ pub fn calculate_matchings<'a>(
                     right.kind()
                 );
                 let mut result = label_matchings;
-                result.extend(Matchings::from_single(
-                    UnorderedPair(left, right),
-                    MatchingEntry::new(left, right, label_score + root_matching),
-                ));
+                result.push(left, right, label_score + root_matching);
                 result
             } else {
                 log::debug!(
@@ -63,11 +58,8 @@ pub fn calculate_matchings<'a>(
                     .unwrap_or(0);
 
                 let mut result = label_matchings;
+                result.push(left, right, label_score + assignment_score);
                 result.extend(assignment_matchings);
-                result.extend(Matchings::from_single(
-                    UnorderedPair(left, right),
-                    MatchingEntry::new(left, right, label_score + assignment_score),
-                ));
                 result
             }
         }

--- a/matching/src/unordered/mod.rs
+++ b/matching/src/unordered/mod.rs
@@ -1,14 +1,11 @@
-use std::collections::{HashMap, HashSet};
-
-use model::cst_node::{CSTNode, Delimiters, NonTerminal};
-
 mod assignment_problem;
+mod unique_label;
 
 use crate::Matchings;
 
 pub fn calculate_subtree_matching<'a>(
-    left: &'a NonTerminal<'a>,
-    right: &'a NonTerminal<'a>,
+    left: &'a model::cst_node::NonTerminal<'a>,
+    right: &'a model::cst_node::NonTerminal<'a>,
     matchings: &mut Matchings<'a>,
 ) -> usize {
     log::debug!(
@@ -18,7 +15,7 @@ pub fn calculate_subtree_matching<'a>(
     );
 
     let (label_matchings, label_score, remaining_left_children, remaining_right_children) =
-        calculate_label_matchings(left, right);
+        unique_label::calculate_label_matchings(left, right);
 
     matchings.extend(label_matchings);
 
@@ -52,196 +49,10 @@ pub fn calculate_subtree_matching<'a>(
     }
 }
 
-fn calculate_label_matchings<'a>(
-    left_nt: &'a NonTerminal<'a>,
-    right_nt: &'a NonTerminal<'a>,
-) -> (
-    crate::Matchings<'a>,
-    usize,
-    Vec<&'a CSTNode<'a>>,
-    Vec<&'a CSTNode<'a>>,
-) {
-    let left_children: Vec<&'a CSTNode<'a>> = left_nt
-        .get_children()
-        .iter()
-        .filter(|child| !is_delimiter(child, left_nt.delimiters))
-        .collect();
-    let right_children: Vec<&'a CSTNode<'a>> = right_nt
-        .get_children()
-        .iter()
-        .filter(|child| !is_delimiter(child, right_nt.delimiters))
-        .collect();
-
-    let left_identifier_counts = identifier_counts(&left_children);
-    let right_identifier_counts = identifier_counts(&right_children);
-    let shared_unique_identifiers =
-        shared_unique_identifiers(&left_identifier_counts, &right_identifier_counts);
-
-    let right_children_by_identifier: HashMap<_, _> = right_children
-        .iter()
-        .filter_map(|child| child_identifier(child).map(|identifier| (identifier, *child)))
-        .collect();
-
-    let mut result = crate::Matchings::empty();
-    let mut matched_identifiers = HashSet::new();
-    let mut remaining_left = Vec::new();
-    let mut label_score = 0;
-
-    for left_child in left_children {
-        match child_identifier(left_child) {
-            Some(identifier) if shared_unique_identifiers.contains(&identifier) => {
-                if let Some(right_child) = right_children_by_identifier.get(&identifier) {
-                    let child_matchings = crate::calculate_matchings(left_child, right_child);
-
-                    if let Some(matching_entry) =
-                        child_matchings.get_matching_entry(left_child, right_child)
-                    {
-                        if matching_entry.score >= 1 {
-                            matched_identifiers.insert(identifier);
-                            label_score += matching_entry.score;
-                            result.extend(child_matchings);
-                            continue;
-                        }
-                    }
-                }
-
-                remaining_left.push(left_child);
-            }
-            _ => remaining_left.push(left_child),
-        }
-    }
-
-    let mut remaining_right = Vec::new();
-    for right_child in right_children {
-        match child_identifier(right_child) {
-            Some(identifier) if matched_identifiers.contains(&identifier) => {}
-            _ => remaining_right.push(right_child),
-        }
-    }
-
-    (result, label_score, remaining_left, remaining_right)
-}
-
-fn identifier_counts<'a>(children: &[&'a CSTNode<'a>]) -> HashMap<String, usize> {
-    let mut counts = HashMap::with_capacity(children.len());
-
-    for child in children {
-        if let Some(identifier) = child_identifier(child) {
-            *counts.entry(identifier).or_insert(0) += 1;
-        }
-    }
-
-    counts
-}
-
-fn shared_unique_identifiers(
-    left_counts: &HashMap<String, usize>,
-    right_counts: &HashMap<String, usize>,
-) -> HashSet<String> {
-    left_counts
-        .iter()
-        .filter_map(|(identifier, left_count)| {
-            (left_count == &1 && right_counts.get(identifier) == Some(&1))
-                .then_some(identifier.clone())
-        })
-        .collect()
-}
-
-fn child_identifier<'a>(child: &'a CSTNode<'a>) -> Option<String> {
-    match child {
-        CSTNode::Terminal(terminal) => Some(format!(
-            "terminal:{}\u{1f}{}",
-            terminal.kind, terminal.value
-        )),
-        CSTNode::NonTerminal(non_terminal) => non_terminal.get_identifier().map(|identifier| {
-            format!(
-                "nonterminal:{}\u{1f}{}",
-                non_terminal.kind,
-                identifier.join("\u{1f}")
-            )
-        }),
-    }
-}
-
-fn is_delimiter(child: &CSTNode<'_>, delimiters: Option<&Delimiters<'_>>) -> bool {
-    delimiters.is_some_and(|delimiters| delimiters.is_delimiter(child))
-}
-
 #[cfg(test)]
 mod tests {
-    use model::{
-        cst_node::{NonTerminal, Terminal},
-        CSTNode, Point,
-    };
-
-    use crate::{unordered::identifier_counts, Matchings};
-
-    fn all_children_have_unique_identifiers(node: &NonTerminal) -> bool {
-        let children: Vec<&CSTNode<'_>> = node.get_children().iter().collect();
-        let counts = identifier_counts(&children);
-        counts.values().all(|count| *count == 1)
-    }
-
-    #[test]
-    fn it_accepts_children_with_unique_identifiers() {
-        let left_child = CSTNode::Terminal(Terminal {
-            id: uuid::Uuid::new_v4(),
-            kind: "identifier",
-            value: "left",
-            start_position: Point { row: 0, column: 0 },
-            end_position: Point { row: 0, column: 4 },
-            leading_white_space: None,
-        });
-        let right_child = CSTNode::Terminal(Terminal {
-            id: uuid::Uuid::new_v4(),
-            kind: "identifier",
-            value: "right",
-            start_position: Point { row: 0, column: 5 },
-            end_position: Point { row: 0, column: 10 },
-            leading_white_space: None,
-        });
-        let node = NonTerminal {
-            id: uuid::Uuid::new_v4(),
-            kind: "object",
-            children: vec![left_child, right_child],
-            start_position: Point { row: 0, column: 0 },
-            end_position: Point { row: 0, column: 10 },
-            are_children_unordered: true,
-            identifier: None,
-            leading_white_space: None,
-            delimiters: None,
-        };
-
-        assert!(all_children_have_unique_identifiers(&node));
-    }
-
-    #[test]
-    fn it_rejects_children_with_duplicate_identifiers() {
-        let shared_child = CSTNode::NonTerminal(NonTerminal {
-            id: uuid::Uuid::new_v4(),
-            kind: "pair",
-            children: vec![],
-            start_position: Point { row: 0, column: 0 },
-            end_position: Point { row: 0, column: 1 },
-            are_children_unordered: false,
-            identifier: Some(vec!["abbr"]),
-            leading_white_space: None,
-            delimiters: None,
-        });
-        let node = NonTerminal {
-            id: uuid::Uuid::new_v4(),
-            kind: "object",
-            children: vec![shared_child.clone(), shared_child],
-            start_position: Point { row: 0, column: 0 },
-            end_position: Point { row: 0, column: 1 },
-            are_children_unordered: true,
-            identifier: None,
-            leading_white_space: None,
-            delimiters: None,
-        };
-
-        assert!(!all_children_have_unique_identifiers(&node));
-    }
+    use crate::Matchings;
+    use model::{cst_node::NonTerminal, CSTNode, Point};
 
     #[test]
     fn it_combines_unique_label_and_assignment_matchings() {

--- a/matching/src/unordered/unique_label.rs
+++ b/matching/src/unordered/unique_label.rs
@@ -1,0 +1,193 @@
+use std::collections::{HashMap, HashSet};
+
+use model::cst_node::{CSTNode, Delimiters};
+
+pub fn calculate_label_matchings<'a>(
+    left_nt: &'a model::cst_node::NonTerminal<'a>,
+    right_nt: &'a model::cst_node::NonTerminal<'a>,
+) -> (
+    crate::Matchings<'a>,
+    usize,
+    Vec<&'a CSTNode<'a>>,
+    Vec<&'a CSTNode<'a>>,
+) {
+    let left_children: Vec<&'a CSTNode<'a>> = left_nt
+        .get_children()
+        .iter()
+        .filter(|child| !is_delimiter(child, left_nt.delimiters))
+        .collect();
+    let right_children: Vec<&'a CSTNode<'a>> = right_nt
+        .get_children()
+        .iter()
+        .filter(|child| !is_delimiter(child, right_nt.delimiters))
+        .collect();
+
+    let left_identifier_counts = identifier_counts(&left_children);
+    let right_identifier_counts = identifier_counts(&right_children);
+    let shared_unique_identifiers =
+        shared_unique_identifiers(&left_identifier_counts, &right_identifier_counts);
+
+    let right_children_by_identifier: HashMap<_, _> = right_children
+        .iter()
+        .filter_map(|child| child_identifier(child).map(|identifier| (identifier, *child)))
+        .collect();
+
+    let mut result = crate::Matchings::empty();
+    let mut matched_identifiers = HashSet::new();
+    let mut remaining_left = Vec::new();
+    let mut label_score = 0;
+
+    for left_child in left_children {
+        match child_identifier(left_child) {
+            Some(identifier) if shared_unique_identifiers.contains(&identifier) => {
+                if let Some(right_child) = right_children_by_identifier.get(&identifier) {
+                    let child_matchings = crate::calculate_matchings(left_child, right_child);
+
+                    if let Some(matching_entry) =
+                        child_matchings.get_matching_entry(left_child, right_child)
+                    {
+                        if matching_entry.score >= 1 {
+                            matched_identifiers.insert(identifier);
+                            label_score += matching_entry.score;
+                            result.extend(child_matchings);
+                            continue;
+                        }
+                    }
+                }
+
+                remaining_left.push(left_child);
+            }
+            _ => remaining_left.push(left_child),
+        }
+    }
+
+    let mut remaining_right = Vec::new();
+    for right_child in right_children {
+        match child_identifier(right_child) {
+            Some(identifier) if matched_identifiers.contains(&identifier) => {}
+            _ => remaining_right.push(right_child),
+        }
+    }
+
+    (result, label_score, remaining_left, remaining_right)
+}
+
+fn identifier_counts<'a>(children: &[&'a CSTNode<'a>]) -> HashMap<String, usize> {
+    let mut counts = HashMap::with_capacity(children.len());
+
+    for child in children {
+        if let Some(identifier) = child_identifier(child) {
+            *counts.entry(identifier).or_insert(0) += 1;
+        }
+    }
+
+    counts
+}
+
+fn shared_unique_identifiers(
+    left_counts: &HashMap<String, usize>,
+    right_counts: &HashMap<String, usize>,
+) -> HashSet<String> {
+    left_counts
+        .iter()
+        .filter_map(|(identifier, left_count)| {
+            (left_count == &1 && right_counts.get(identifier) == Some(&1))
+                .then_some(identifier.clone())
+        })
+        .collect()
+}
+
+fn child_identifier<'a>(child: &'a CSTNode<'a>) -> Option<String> {
+    match child {
+        CSTNode::Terminal(terminal) => Some(format!(
+            "terminal:{}\u{1f}{}",
+            terminal.kind, terminal.value
+        )),
+        CSTNode::NonTerminal(non_terminal) => non_terminal.get_identifier().map(|identifier| {
+            format!(
+                "nonterminal:{}\u{1f}{}",
+                non_terminal.kind,
+                identifier.join("\u{1f}")
+            )
+        }),
+    }
+}
+
+fn is_delimiter(child: &CSTNode<'_>, delimiters: Option<&Delimiters<'_>>) -> bool {
+    delimiters.is_some_and(|delimiters| delimiters.is_delimiter(child))
+}
+
+#[cfg(test)]
+mod tests {
+    use model::{
+        cst_node::{NonTerminal, Terminal},
+        CSTNode, Point,
+    };
+
+    fn all_children_have_unique_identifiers(node: &NonTerminal) -> bool {
+        let children: Vec<&CSTNode<'_>> = node.get_children().iter().collect();
+        let counts = super::identifier_counts(&children);
+        counts.values().all(|count| *count == 1)
+    }
+
+    #[test]
+    fn it_accepts_children_with_unique_identifiers() {
+        let left_child = CSTNode::Terminal(Terminal {
+            id: uuid::Uuid::new_v4(),
+            kind: "identifier",
+            value: "left",
+            start_position: Point { row: 0, column: 0 },
+            end_position: Point { row: 0, column: 4 },
+            leading_white_space: None,
+        });
+        let right_child = CSTNode::Terminal(Terminal {
+            id: uuid::Uuid::new_v4(),
+            kind: "identifier",
+            value: "right",
+            start_position: Point { row: 0, column: 5 },
+            end_position: Point { row: 0, column: 10 },
+            leading_white_space: None,
+        });
+        let node = NonTerminal {
+            id: uuid::Uuid::new_v4(),
+            kind: "object",
+            children: vec![left_child, right_child],
+            start_position: Point { row: 0, column: 0 },
+            end_position: Point { row: 0, column: 10 },
+            are_children_unordered: true,
+            identifier: None,
+            leading_white_space: None,
+            delimiters: None,
+        };
+
+        assert!(all_children_have_unique_identifiers(&node));
+    }
+
+    #[test]
+    fn it_rejects_children_with_duplicate_identifiers() {
+        let shared_child = CSTNode::NonTerminal(NonTerminal {
+            id: uuid::Uuid::new_v4(),
+            kind: "pair",
+            children: vec![],
+            start_position: Point { row: 0, column: 0 },
+            end_position: Point { row: 0, column: 1 },
+            are_children_unordered: false,
+            identifier: Some(vec!["abbr"]),
+            leading_white_space: None,
+            delimiters: None,
+        });
+        let node = NonTerminal {
+            id: uuid::Uuid::new_v4(),
+            kind: "object",
+            children: vec![shared_child.clone(), shared_child],
+            start_position: Point { row: 0, column: 0 },
+            end_position: Point { row: 0, column: 1 },
+            are_children_unordered: true,
+            identifier: None,
+            leading_white_space: None,
+            delimiters: None,
+        };
+
+        assert!(!all_children_have_unique_identifiers(&node));
+    }
+}

--- a/merge/src/ordered_merge.rs
+++ b/merge/src/ordered_merge.rs
@@ -477,7 +477,7 @@ pub fn ordered_merge<'a>(
 mod tests {
     use std::{borrow::Cow, vec};
 
-    use matching::{ordered, Matchings};
+    use matching::Matchings;
     use model::{cst_node::NonTerminal, cst_node::Terminal, CSTNode, Point};
 
     use crate::{MergeError, MergedCSTNode};
@@ -491,9 +491,9 @@ mod tests {
         expected_merge: &'a MergedCSTNode<'a>,
     ) -> Result<(), MergeError> {
         let mut log_state = None;
-        let matchings_base_parent_a = ordered::calculate_matchings(base, parent_a);
-        let matchings_base_parent_b = ordered::calculate_matchings(base, parent_b);
-        let matchings_parents = ordered::calculate_matchings(parent_a, parent_b);
+        let matchings_base_parent_a = matching::calculate_matchings(base, parent_a);
+        let matchings_base_parent_b = matching::calculate_matchings(base, parent_b);
+        let matchings_parents = matching::calculate_matchings(parent_a, parent_b);
 
         let merged_tree = ordered_merge(
             parent_a.try_into().unwrap(),
@@ -525,9 +525,9 @@ mod tests {
         expected_merge: &MergedCSTNode,
     ) -> Result<(), MergeError> {
         let mut log_state = None;
-        let matchings_base_parent_a = ordered::calculate_matchings(base, parent_a);
-        let matchings_base_parent_b = ordered::calculate_matchings(base, parent_b);
-        let matchings_parents = ordered::calculate_matchings(parent_a, parent_b);
+        let matchings_base_parent_a = matching::calculate_matchings(base, parent_a);
+        let matchings_base_parent_b = matching::calculate_matchings(base, parent_b);
+        let matchings_parents = matching::calculate_matchings(parent_a, parent_b);
 
         let merged_tree = ordered_merge(
             parent_a.try_into().unwrap(),
@@ -930,9 +930,9 @@ mod tests {
             ..Default::default()
         });
 
-        let matchings_base_parent_a = ordered::calculate_matchings(&base, &parent_a);
-        let matchings_base_parent_b = ordered::calculate_matchings(&base, &parent_b);
-        let matchings_parents = ordered::calculate_matchings(&parent_a, &parent_b);
+        let matchings_base_parent_a = matching::calculate_matchings(&base, &parent_a);
+        let matchings_base_parent_b = matching::calculate_matchings(&base, &parent_b);
+        let matchings_parents = matching::calculate_matchings(&parent_a, &parent_b);
 
         let merged_tree = ordered_merge(
             (&parent_a).try_into().unwrap(),

--- a/merge/src/unordered_merge.rs
+++ b/merge/src/unordered_merge.rs
@@ -262,7 +262,7 @@ pub fn unordered_merge<'a>(
 
 #[cfg(test)]
 mod tests {
-    use matching::{unordered::calculate_matchings, Matchings};
+    use matching::Matchings;
     use model::{
         cst_node::{Delimiters, NonTerminal, Terminal},
         CSTNode, Point,
@@ -279,9 +279,9 @@ mod tests {
         expected_merge: &MergedCSTNode,
     ) -> Result<(), MergeError> {
         let mut log_state = None;
-        let matchings_base_parent_a = calculate_matchings(base, parent_a);
-        let matchings_base_parent_b = calculate_matchings(base, parent_b);
-        let matchings_parents = calculate_matchings(parent_a, parent_b);
+        let matchings_base_parent_a = matching::calculate_matchings(base, parent_a);
+        let matchings_base_parent_b = matching::calculate_matchings(base, parent_b);
+        let matchings_parents = matching::calculate_matchings(parent_a, parent_b);
 
         let merged_tree = unordered_merge(
             parent_a.try_into().unwrap(),
@@ -313,9 +313,9 @@ mod tests {
         expected_merge: &MergedCSTNode,
     ) -> Result<(), MergeError> {
         let mut log_state = None;
-        let matchings_base_parent_a = calculate_matchings(base, parent_a);
-        let matchings_base_parent_b = calculate_matchings(base, parent_b);
-        let matchings_parents = calculate_matchings(parent_a, parent_b);
+        let matchings_base_parent_a = matching::calculate_matchings(base, parent_a);
+        let matchings_base_parent_b = matching::calculate_matchings(base, parent_b);
+        let matchings_parents = matching::calculate_matchings(parent_a, parent_b);
 
         let merged_tree = unordered_merge(
             parent_a.try_into().unwrap(),


### PR DESCRIPTION
## Description

Refactor the matching module to centralize the matching calculation logic and make ordered/unordered matching algorithms operate on subtrees instead of complete node pairs.

## Changes

- Extract the top-level matching orchestration into a new `calculate` module.
  - `calculate_matchings` now owns the lifecycle of a matching computation.
  - Ordered and unordered matchers only calculate subtree scores and populate discovered matchings.

- Rename the `Matches` trait to `CanMatch` to better represent its purpose.
  - The trait now exposes `can_match`, making it clear that it only checks whether two nodes are compatible, not whether they are fully matched.

- Refactor ordered matching:
  - `ordered::calculate_matchings` was replaced by `ordered::calculate_subtree_matching`.
  - The ordered matcher now returns the subtree score instead of creating the complete `Matchings` structure.
  - Root matching is now handled consistently by the top-level calculator.

- Refactor unordered matching:
  - Split unique-label matching into its own module.
  - `unordered::calculate_subtree_matching` now combines:
    - unique-label matching
    - assignment problem matching
  - Assignment matching now returns only the calculated score and appends child matchings into the shared `Matchings` instance.

- Improve `Matchings`:
  - Add capacity initialization to reduce reallocations.
  - Simplify extending and inserting matchings through `push`.
  - Prevent replacing an existing matching with a lower score.
  - Add `len` and `is_empty` helpers.

- Hide internal implementation modules (`ordered` and `unordered`) from the public API.
  - Consumers now only interact with `matching::calculate_matchings`.

## Motivation

Previously, the matching algorithms were responsible for both:
1. calculating subtree similarities, and
2. managing the resulting matching collection.

This made the ordered and unordered implementations duplicate parts of the orchestration logic and made it harder to evolve the matching algorithm.

By moving the orchestration into a single place, all matching strategies now share the same flow:

1. Validate that nodes can match.
2. Calculate child/subtree matching score.
3. Add the root matching.
4. Return the complete set of matchings.

This also makes future matching strategies easier to introduce since they only need to implement subtree matching behavior.